### PR TITLE
Expose `contentLength` property

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arnavmq",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "ArnavMQ is a RabbitMQ wrapper",
   "keywords": [
     "rabbitmq",

--- a/src/modules/message-parsers.js
+++ b/src/modules/message-parsers.js
@@ -7,6 +7,10 @@ const { serializeError, deserializeError } = require('serialize-error');
 module.exports.in = (msg) => {
   // if sender put a json header, we parse it to avoid the pain for the consumer
   if (msg.content) {
+    if (!msg.properties.contentLength) {
+      msg.properties.contentLength = msg.content.length;
+    }
+
     if (msg.properties.contentType === 'application/json') {
       const content = JSON.parse(msg.content.toString());
       if (content && content.error && content.error instanceof Object) {

--- a/test/disconnect-spec.js
+++ b/test/disconnect-spec.js
@@ -6,9 +6,8 @@ const utils = require('../src/modules/utils');
 /* eslint func-names: "off" */
 /* eslint prefer-arrow-callback: "off" */
 describe('disconnections', function () {
+  before(docker.rm);
   before(() => docker.run().then(docker.start));
-
-  after(docker.rm);
 
   describe('regular pub/sub', () => {
     const queue = 'disco:test';

--- a/test/producer-consumer-spec.js
+++ b/test/producer-consumer-spec.js
@@ -14,9 +14,8 @@ let letters = 0;
 /* eslint func-names: "off" */
 /* eslint prefer-arrow-callback: "off" */
 describe('producer/consumer', function () {
+  before(docker.rm);
   before(() => docker.run().then(docker.start));
-
-  after(docker.rm);
 
   describe('msg delevering', () => {
     before(() => arnavmq.consumer.consume(fixtures.queues[0], () => {

--- a/test/producer-consumer-spec.js
+++ b/test/producer-consumer-spec.js
@@ -64,6 +64,19 @@ describe('producer/consumer', function () {
         });
     });
 
+    it('should receive contentLength property', () => {
+      const queueName = 'test-headers';
+      const payload = { a: 1 };
+      const messageSize = Buffer.byteLength(JSON.stringify(payload));
+      return arnavmq.consumer.consume(queueName, (message, properties) => Promise.resolve({ message, properties }))
+        .then(() => arnavmq.producer.produce(queueName, payload, { rpc: true }))
+        .then((result) => {
+          assert.deepEqual(result.message, payload);
+          assert.deepEqual(result.properties.contentType, 'application/json');
+          assert.deepEqual(result.properties.contentLength, messageSize);
+        });
+    });
+
     it('should be able to consume message sent by producer to queue [test-queue-0]', () => {
       letters += 1;
       return arnavmq.producer.produce(fixtures.queues[0], { msg: uuid.v4() })

--- a/test/rpc-spec.js
+++ b/test/rpc-spec.js
@@ -9,9 +9,8 @@ const fixtures = {
 };
 
 describe('Producer/Consumer RPC messaging:', () => {
+  before(docker.rm);
   before(() => docker.run().then(docker.start));
-
-  after(docker.rm);
 
   it('should be able to create a consumer that returns a message if called as RPC [rpc-queue-0]', () => arnavmq.consumer.consume(fixtures.queues[0], () => 'Power Ranger Red')
     .then((created) => {


### PR DESCRIPTION
For consumer to know what’s the length of the payload without needing to
serialise it again.