### PR TITLE
Add producer retry limit.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,6 +11,6 @@
     "comma-dangle": 0,
     "max-classes-per-file": 0,
     "max-len": ["error", {"code": 190, "ignoreComments": true, "ignoreUrls": true}],
-    "no-underscore-dangle": [1, { "allow": ["_config", "_connection", "_maxListeners"] }]
+    "no-underscore-dangle": [1, { "allow": ["_config", "_connection", "_maxListeners"], "allowAfterThis": true }]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -419,3 +419,5 @@ fabric.properties
 
 # package-lock
 package-lock.json
+
+.vscode/

--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ You can specify a config object, properties and default values are:
     // time between two reconnect (ms)
     timeout: 1000,
 
+    // the maximum number of retries when trying to send a message before throwing error when failing. If set to '0' will not retry. If set to less then '0', will retry indefinitely.
+    producerMaxRetries: -1,
+
     // default timeout for RPC calls. If set to '0' there will be none.
     rpcTimeout: 1000,
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arnavmq",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "ArnavMQ is a RabbitMQ wrapper",
   "keywords": [
     "rabbitmq",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-react": "^7.21.5",
     "eslint-plugin-react-hooks": "^4.2.0",
-    "faker": "^5.4.0",
     "mocha": "^8.2.1",
     "nyc": "^15.1.0",
     "sinon": "^9.2.4"

--- a/package.json
+++ b/package.json
@@ -40,8 +40,10 @@
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-react": "^7.21.5",
     "eslint-plugin-react-hooks": "^4.2.0",
+    "faker": "^5.4.0",
     "mocha": "^8.2.1",
-    "nyc": "^15.1.0"
+    "nyc": "^15.1.0",
+    "sinon": "^9.2.4"
   },
   "engines": {
     "node": ">=10"

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,9 @@ module.exports = (config) => {
     // time between two reconnect (ms)
     timeout: 1000,
 
+    // the maximum number of retries when trying to send a message before throwing error when failing. If set to '0' will not retry. If set to less then '0', will retry indefinitely.
+    producerMaxRetries: -1,
+
     // default timeout for RPC calls. If set to '0' there will be none.
     rpcTimeout: 15000,
 

--- a/src/modules/consumer.js
+++ b/src/modules/consumer.js
@@ -1,7 +1,7 @@
 const parsers = require('./message-parsers');
 const utils = require('./utils');
 
-const loggerAlias = 'bmq:consumer';
+const loggerAlias = 'amq:consumer';
 
 class Consumer {
   constructor(connection) {
@@ -95,7 +95,7 @@ class Consumer {
 
         return true;
       });
-    // in case of any error creating the channel, wait for some time and then try to reconnect again (to avoid overflow)
+      // in case of any error creating the channel, wait for some time and then try to reconnect again (to avoid overflow)
     }).catch(() => utils.timeoutPromise(this._connection.config.timeout)
       .then(() => this.subscribe(queue, options, callback)));
   }

--- a/src/modules/consumer.js
+++ b/src/modules/consumer.js
@@ -1,7 +1,7 @@
 const parsers = require('./message-parsers');
 const utils = require('./utils');
 
-const loggerAlias = 'amq:consumer';
+const loggerAlias = 'arnav_mq:consumer';
 
 class Consumer {
   constructor(connection) {

--- a/src/modules/producer.js
+++ b/src/modules/producer.js
@@ -4,8 +4,7 @@ const parsers = require('./message-parsers');
 const Deferred = require('../classes/deferred');
 
 const ERRORS = {
-  TIMEOUT: 'Timeout reached',
-  BUFFER_FULL: 'Buffer is full'
+  TIMEOUT: 'Timeout reached'
 };
 
 const loggerAlias = 'bmq:producer';
@@ -213,7 +212,7 @@ class Producer {
 
       return this.checkRpc(queue, parsers.out(message, settings), settings);
     }).catch((err) => {
-      if (err instanceof ProducerError || [ERRORS.TIMEOUT, ERRORS.BUFFER_FULL].includes(err.message)) {
+      if (err instanceof ProducerError || ERRORS.TIMEOUT === err.message) {
         throw err;
       }
 

--- a/src/modules/producer.js
+++ b/src/modules/producer.js
@@ -202,7 +202,7 @@ class Producer {
       message = { ...msg };
     }
 
-    return this._sendToQueue(queue, msg, settings, 0)
+    return this._sendToQueue(queue, message, settings, 0);
   }
 
   _sendToQueue(queue, message, settings, currentRetryNumber) {
@@ -229,15 +229,15 @@ class Producer {
 
   _shouldRetry(error, currentRetryNumber) {
     if (error instanceof ProducerError || error.message === ERRORS.TIMEOUT) {
-      return false
+      return false;
     }
-    const maxRetries = this._connection.config.producerMaxRetries
+    const maxRetries = this._connection.config.producerMaxRetries;
     if (maxRetries < 0) {
       // Retry indefinitely...
       return true;
     }
 
-    return currentRetryNumber < maxRetries
+    return currentRetryNumber < maxRetries;
   }
 }
 

--- a/src/modules/producer.js
+++ b/src/modules/producer.js
@@ -7,7 +7,7 @@ const ERRORS = {
   TIMEOUT: 'Timeout reached'
 };
 
-const loggerAlias = 'amq:producer';
+const loggerAlias = 'arnav_mq:producer';
 
 class ProducerError extends Error {
   constructor({ name, message }) {

--- a/src/modules/producer.js
+++ b/src/modules/producer.js
@@ -7,7 +7,7 @@ const ERRORS = {
   TIMEOUT: 'Timeout reached'
 };
 
-const loggerAlias = 'bmq:producer';
+const loggerAlias = 'amq:producer';
 
 class ProducerError extends Error {
   constructor({ name, message }) {

--- a/test/disconnect-spec.js
+++ b/test/disconnect-spec.js
@@ -1,7 +1,10 @@
 const assert = require('assert');
 const docker = require('./docker');
-const arnavmq = require('../src/index')();
+const arnavmq = require('../src/index')({ producerMaxRetries: -1 });
 const utils = require('../src/modules/utils');
+const faker = require('faker');
+const sinon = require('sinon');
+const amqp = require('amqplib');
 
 /* eslint func-names: "off" */
 /* eslint prefer-arrow-callback: "off" */
@@ -32,6 +35,31 @@ describe('disconnections', function () {
         .then(docker.start)
         .catch(done);
     });
+
+    it('should retry producing only as configured', (done) => {
+      const retryCount = faker.random.number({ min: 2, max: 6 })
+      arnavmq.connection._config.producerMaxRetries = retryCount;
+      const expectedError = 'Fake connection error.';
+      sinon.stub(amqp, 'connect').rejects(new Error(expectedError));
+
+      arnavmq.producer.produce(queue)
+        .then(() => {
+          assert.fail('Should fail to produce and throw error, but did not.')
+        })
+        .catch((e) => {
+          if (e instanceof assert.AssertionError) {
+            done(e)
+            return;
+          }
+          try {
+            sinon.assert.callCount(amqp.connect, retryCount + 1);
+            assert.strictEqual(e.message, 'Fake connection error.')
+            done()
+          } catch (error) {
+            done(error)
+          }
+        });
+    })
   });
 
   describe('RPC', () => {

--- a/test/disconnect-spec.js
+++ b/test/disconnect-spec.js
@@ -1,10 +1,10 @@
 const assert = require('assert');
-const docker = require('./docker');
-const arnavmq = require('../src/index')({ producerMaxRetries: -1 });
-const utils = require('../src/modules/utils');
 const faker = require('faker');
 const sinon = require('sinon');
 const amqp = require('amqplib');
+const docker = require('./docker');
+const arnavmq = require('../src/index')({ producerMaxRetries: -1 });
+const utils = require('../src/modules/utils');
 
 /* eslint func-names: "off" */
 /* eslint prefer-arrow-callback: "off" */
@@ -37,29 +37,29 @@ describe('disconnections', function () {
     });
 
     it('should retry producing only as configured', (done) => {
-      const retryCount = faker.random.number({ min: 2, max: 6 })
+      const retryCount = faker.random.number({ min: 2, max: 6 });
       arnavmq.connection._config.producerMaxRetries = retryCount;
       const expectedError = 'Fake connection error.';
       sinon.stub(amqp, 'connect').rejects(new Error(expectedError));
 
       arnavmq.producer.produce(queue)
         .then(() => {
-          assert.fail('Should fail to produce and throw error, but did not.')
+          assert.fail('Should fail to produce and throw error, but did not.');
         })
         .catch((e) => {
           if (e instanceof assert.AssertionError) {
-            done(e)
+            done(e);
             return;
           }
           try {
             sinon.assert.callCount(amqp.connect, retryCount + 1);
-            assert.strictEqual(e.message, 'Fake connection error.')
-            done()
+            assert.strictEqual(e.message, 'Fake connection error.');
+            done();
           } catch (error) {
-            done(error)
+            done(error);
           }
         });
-    })
+    });
   });
 
   describe('RPC', () => {


### PR DESCRIPTION
Retrying publish indefinitely can cause a memory issues if more and more and more messages are waiting to be published while the connection is down.

By setting `producerMaxRetries` in the configuration, you can now limit the number of publish retries before throwing the exception, so in case of a fluke or a momentary disconnection the message will be retried and sent, but in case of a longer downtime the memory of the application won't explode if there are too many messages trying to be published.

If setting a retry limit, the application should know how to handle failed publish errors by itself.

The `consumer` doesn't have this problem, so we can continue retry reconnecting indefinitely.