### PR TITLE
convert options.timeout to amqp message-level 'expiration' setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ arnavmq.publish('queue:name', { message: 'content' }, { rpc: true, timeout: 1000
 The optional `timeout` option results in a rejection when no answer has been received after the given amount of milliseconds.
 When '0' is given, there will be no timeout for this call.
 This value will overwrite the default timeout set in the config in `rpcTimeout`. **Update:** Message-level timeout is deprecated. 
-Please use amqp's **expiration** option instead.
+Please use amqp's **expiration** option instead. It gives the same rejection for the producer if the timeout is reached, 
+but together with that it also guarantees that this message will not be consumed after the expiration period.
 
 ## Routing keys
 
@@ -117,7 +118,7 @@ You can specify a config object, properties and default values are:
     hostname: process.env.HOSTNAME || process.env.USER || uuid.v4(),
 
     // Deprecated. Use 'logger' instead. The transport to use to debug. If provided, arnavmq will show some logs
-    transport: utils.emptyLogger
+    transport: utils.emptyLogger,
 
     /**
      * A logger object with a log function for each of the log levels ("debug", "info", "warn", or "error").

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ arnavmq.publish('queue:name', { message: 'content' }, { rpc: true, timeout: 1000
 
 The optional `timeout` option results in a rejection when no answer has been received after the given amount of milliseconds.
 When '0' is given, there will be no timeout for this call.
-This value will overwrite the default timeout set in the config in `rpcTimeout`.
+This value will overwrite the default timeout set in the config in `rpcTimeout`. **Update:** Message-level timeout is deprecated. 
+Please use amqp's **expiration** option instead.
 
 ## Routing keys
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arnavmq",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "ArnavMQ is a RabbitMQ wrapper",
   "keywords": [
     "rabbitmq",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arnavmq",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "ArnavMQ is a RabbitMQ wrapper",
   "keywords": [
     "rabbitmq",
@@ -15,7 +15,7 @@
   "scripts": {
     "lint": "eslint .",
     "cover": "test -d .nyc_output && nyc report --reporter lcov",
-    "test": "nyc mocha --recursive --timeout=30000 --exit"
+    "test": "nyc mocha --recursive --timeout=45000 --exit"
   },
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 const uuid = require('uuid');
 const utils = require('./modules/utils');
 const connection = require('./modules/connection');
+const { TRANSPORT_LOGGING_DEPRECATED } = require('./modules/warnings');
 
 /* eslint global-require: "off" */
 module.exports = (config) => {
@@ -46,7 +47,7 @@ module.exports = (config) => {
   };
 
   if (configuration.transport !== utils.emptyLogger) {
-    process.emitWarning("The 'transport' configuration option is deprecated. Please use the 'logger' option instead.", 'DeprecationWarning');
+    utils.emitWarn(TRANSPORT_LOGGING_DEPRECATED);
   }
 
   configuration.prefetch = parseInt(configuration.prefetch, 10) || 0;

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 const uuid = require('uuid');
 const utils = require('./modules/utils');
 const connection = require('./modules/connection');
-const { TRANSPORT_LOGGING_DEPRECATED } = require('./modules/warnings');
+const { ARNAVMQ_TRANSPORT_LOGGER_DEPRECATED } = require('./modules/warnings');
 
 /* eslint global-require: "off" */
 module.exports = (config) => {
@@ -47,7 +47,7 @@ module.exports = (config) => {
   };
 
   if (configuration.transport !== utils.emptyLogger) {
-    utils.emitWarn(TRANSPORT_LOGGING_DEPRECATED);
+    utils.emitWarn(ARNAVMQ_TRANSPORT_LOGGER_DEPRECATED);
   }
 
   configuration.prefetch = parseInt(configuration.prefetch, 10) || 0;

--- a/src/modules/producer.js
+++ b/src/modules/producer.js
@@ -180,12 +180,9 @@ class Producer {
         // Unfortunately, we can do nothing if the message is already consumed and is being processed at the moment
         // when the timeout appears.
         if (options.timeout && options.timeout > 0) {
-          if (this._connection.config.logger) {
-            // TODO: remove that warn after timeout option is removed in scope of major version update
-            this._connection.config.logger.warn({
-              message: `${loggerAlias} using timeout option on message level is deprecated. Please use expiration instead.`,
-            });
-          }
+          utils.emitWarn('ARNAVMQ_MSG_TIMEOUT_DEPRECATED',
+            'using timeout option on message level is deprecated',
+            'Please use expiration instead');
           options.expiration = options.timeout;
         }
         // set expiration if it isn't set yet

--- a/src/modules/producer.js
+++ b/src/modules/producer.js
@@ -180,9 +180,11 @@ class Producer {
         // Unfortunately, we can do nothing if the message is already consumed and is being processed at the moment
         // when the timeout appears.
         if (options.timeout && options.timeout > 0) {
-          utils.emitWarn('ARNAVMQ_MSG_TIMEOUT_DEPRECATED',
+          utils.emitWarn(
+            'ARNAVMQ_MSG_TIMEOUT_DEPRECATED',
             'using timeout option on message level is deprecated',
-            'Please use expiration instead');
+            'Please use expiration instead'
+          );
           options.expiration = options.timeout;
         }
         // set expiration if it isn't set yet

--- a/src/modules/producer.js
+++ b/src/modules/producer.js
@@ -2,6 +2,7 @@ const uuid = require('uuid');
 const pDefer = require('p-defer');
 const utils = require('./utils');
 const parsers = require('./message-parsers');
+const { ARNAVMQ_MSG_TIMEOUT_DEPRECATED } = require('./warnings');
 
 const ERRORS = {
   TIMEOUT: 'Timeout reached',
@@ -180,11 +181,7 @@ class Producer {
         // Unfortunately, we can do nothing if the message is already consumed and is being processed at the moment
         // when the timeout appears.
         if (options.timeout && options.timeout > 0) {
-          utils.emitWarn(
-            'ARNAVMQ_MSG_TIMEOUT_DEPRECATED',
-            'using timeout option on message level is deprecated',
-            'Please use expiration instead'
-          );
+          utils.emitWarn(ARNAVMQ_MSG_TIMEOUT_DEPRECATED);
           options.expiration = options.timeout;
         }
         // set expiration if it isn't set yet

--- a/src/modules/producer.js
+++ b/src/modules/producer.js
@@ -175,7 +175,7 @@ class Producer {
 
         // convert timeout to amqp's expiration. It's message-level expiration.
         // The message will be discarded from a queue once it’s been there longer than the given number of milliseconds
-        // This is needed to avoid the case when the message which is already expired from our pov (via timeout)
+        // This is needed to avoid the case when the message which is already expired from caller's point of view (via timeout)
         // is still waiting in the queue and thus is about to be processed by the consumer.
         // Unfortunately, we can do nothing if the message is already consumed and is being processed at the moment
         // when the timeout appears.

--- a/src/modules/utils.js
+++ b/src/modules/utils.js
@@ -38,7 +38,7 @@ module.exports = {
   emitWarn: function emitWarn(warning) {
     const { code, message, detail } = warning;
     if (!emitWarn.warned) {
-      emitWarn.warned = [];
+      emitWarn.warned = {};
     }
     if (!emitWarn.warned[code]) {
       emitWarn.warned[code] = true;

--- a/src/modules/utils.js
+++ b/src/modules/utils.js
@@ -28,5 +28,22 @@ module.exports = {
    */
   timeoutPromise: (timer) => new Promise((resolve) => {
     setTimeout(resolve, timer);
-  })
+  }),
+
+  /**
+   * A function that allows to emit warnings for a specified code. The idea is to
+   * limit a warning emission to one per a specific code.
+   * @param code {string} required, unique string identifier for a warning event
+   * @param msg {string} required, a warning message
+   * @param detail {string} optional, detailed message to be added to msg
+   */
+  emitWarn: function emitWarn(code, msg, detail) {
+    if (!emitWarn.warned) {
+      emitWarn.warned = [];
+    }
+    if (!emitWarn.warned[code]) {
+      emitWarn.warned[code] = true;
+      process.emitWarning(msg, { code, detail });
+    }
+  }
 };

--- a/src/modules/utils.js
+++ b/src/modules/utils.js
@@ -33,17 +33,16 @@ module.exports = {
   /**
    * A function that allows to emit warnings for a specified code. The idea is to
    * limit a warning emission to one per a specific code.
-   * @param code {string} required, unique string identifier for a warning event
-   * @param msg {string} required, a warning message
-   * @param detail {string} optional, detailed message to be added to msg
+   * @param warning - {code: string, detail: string, message: string}
    */
-  emitWarn: function emitWarn(code, msg, detail) {
+  emitWarn: function emitWarn(warning) {
+    const { code, message, detail } = warning;
     if (!emitWarn.warned) {
       emitWarn.warned = [];
     }
     if (!emitWarn.warned[code]) {
       emitWarn.warned[code] = true;
-      process.emitWarning(msg, { code, detail });
+      process.emitWarning(message, { code, detail });
     }
   }
 };

--- a/src/modules/warnings.js
+++ b/src/modules/warnings.js
@@ -10,7 +10,7 @@ module.exports = {
     detail: 'Please use expiration instead'
   },
   ARNAVMQ_TRANSPORT_LOGGER_DEPRECATED: {
-    code: 'TRANSPORT_LOGGING_DEPRECATED',
+    code: 'ARNAVMQ_TRANSPORT_LOGGER_DEPRECATED',
     message: "The 'transport' configuration option is deprecated",
     detail: "Please use the 'logger' option instead"
   }

--- a/src/modules/warnings.js
+++ b/src/modules/warnings.js
@@ -1,0 +1,12 @@
+/**
+ * This script is kind of dictionary for possible different types of warning in the lib.
+ * Warning object is a value (string code is a key) and has the following structure:
+ * @type {code: string, detail: string, message: string}
+ */
+module.exports = {
+  ARNAVMQ_MSG_TIMEOUT_DEPRECATED: {
+    code: 'ARNAVMQ_MSG_TIMEOUT_DEPRECATED',
+    message: 'using timeout option on message level is deprecated',
+    detail: 'Please use expiration instead'
+  }
+};

--- a/src/modules/warnings.js
+++ b/src/modules/warnings.js
@@ -9,7 +9,7 @@ module.exports = {
     message: 'using timeout option on message level is deprecated',
     detail: 'Please use expiration instead'
   },
-  TRANSPORT_LOGGING_DEPRECATED: {
+  ARNAVMQ_TRANSPORT_LOGGER_DEPRECATED: {
     code: 'TRANSPORT_LOGGING_DEPRECATED',
     message: "The 'transport' configuration option is deprecated",
     detail: "Please use the 'logger' option instead"

--- a/src/modules/warnings.js
+++ b/src/modules/warnings.js
@@ -8,5 +8,10 @@ module.exports = {
     code: 'ARNAVMQ_MSG_TIMEOUT_DEPRECATED',
     message: 'using timeout option on message level is deprecated',
     detail: 'Please use expiration instead'
+  },
+  TRANSPORT_LOGGING_DEPRECATED: {
+    code: 'TRANSPORT_LOGGING_DEPRECATED',
+    message: "The 'transport' configuration option is deprecated",
+    detail: "Please use the 'logger' option instead"
   }
 };

--- a/test/disconnect-spec.js
+++ b/test/disconnect-spec.js
@@ -62,7 +62,7 @@ describe('disconnections', function () {
     it('should be able to re-register to consume messages between connection failures', (done) => {
       let counter = 0;
       const checkReceived = (cnt) => {
-        if (cnt === 50) done();
+        if (cnt === 20) done();
       };
       arnavmq.connection._config.rpcTimeout = 0;
       arnavmq.consumer.consume(queue, () => {
@@ -70,11 +70,11 @@ describe('disconnections', function () {
         return counter;
       })
         .then(() => arnavmq.producer.produce(queue, undefined, { rpc: true }).then(checkReceived))
-        .then(() => utils.timeoutPromise(500))
+        .then(() => utils.timeoutPromise(100))
         .then(() => assert(counter))
         .then(docker.stop)
         .then(() => {
-          for (let i = counter; i < 50; i += 1) {
+          for (let i = counter; i < 20; i += 1) {
             arnavmq.producer.produce(queue, undefined, { rpc: true }).then(checkReceived);
           }
         })

--- a/test/producer-consumer-spec.js
+++ b/test/producer-consumer-spec.js
@@ -5,7 +5,7 @@ const utils = require('../src/modules/utils');
 const docker = require('./docker');
 
 const fixtures = {
-  queues: ['test-queue-0', 'test-queue-1', 'test-queue-2', 'test-queue-3'],
+  queues: ['test-queue-0', 'test-queue-1', 'test-queue-2', 'test-queue-3', 'test-queue-4', 'test-queue-5'],
   routingKey: 'queue-routing-key'
 };
 
@@ -161,12 +161,30 @@ describe('producer/consumer', function () {
           assert.equal(e.message, 'Timeout reached');
         });
     });
+
+    it('should not deliver message if timeout is reached ', (done) => {
+      // (prefetch + 1) messages will be sent. The last one doesn't have to be consumed as it has to be discarded while waiting in the queue
+      let receivedCounter = 0;
+      const numMsgsToSend = arnavmq.connection._config.prefetch + 1;
+      arnavmq.consumer.consume(fixtures.queues[5], () => {
+        receivedCounter += 1;
+        return utils.timeoutPromise(500);
+      })
+        .then(() => Promise.all(Array.from({ length: numMsgsToSend }, (v, k) => arnavmq.producer.produce(fixtures.queues[5], { a: k }, { rpc: true, timeout: 200 }))))
+        .catch(() => {
+          // last message promise is rejected due to timeout. Let's wait a sec to be sure that message hasn't been consumed
+          setTimeout(() => {
+            assert.equal(receivedCounter, numMsgsToSend - 1);
+            done();
+          }, 1000);
+        });
+    });
   });
 
   describe('error', () => {
     it('should not be consumed', (done) => {
-      arnavmq.consumer.consume('test-queue-5', () => ({ error: new Error('Error test') }))
-        .then(() => arnavmq.producer.produce('test-queue-5', {}, { rpc: true }))
+      arnavmq.consumer.consume(fixtures.queues[4], () => ({ error: new Error('Error test') }))
+        .then(() => arnavmq.producer.produce(fixtures.queues[4], {}, { rpc: true }))
         .then((response) => {
           assert(response.error);
           assert(response.error instanceof Error);


### PR DESCRIPTION
The main idea of this PR is to let the message-broker know that we have a message-level expiration, in other words: if the timeout has been reached while the message is still in the queue, we don't want it to be consumed and processed. I'd like to avoid the situation when the producer is notified that the message hasn't been delivered due to timeout, but the consumer knows nothing about the timeout and starts processing the message. 
Of course, we have another case when the message is consumed before timeout but stuck in long-running processing...
But at least it's getting a bit better with this code change.
Minor thing:
* increase timeout for tests, as locally tests take up to 33 sec (30 sec is not enough for me)
