### PR TITLE
comment out parts of code forcing to use options.expiration instead options.timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arnavmq",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "ArnavMQ is a RabbitMQ wrapper",
   "keywords": [
     "rabbitmq",

--- a/src/modules/producer.js
+++ b/src/modules/producer.js
@@ -196,7 +196,7 @@ class Producer {
         this.amqpRPCQueues[queue][corrId] = responsePromise;
 
         //  Using given timeout or default one
-        const timeout = options.expiration || 0;
+        const timeout = options.expiration || options.timeout || this._connection.config.rpcTimeout || 0;
         if (timeout > 0) {
           this.prepareTimeoutRpc(queue, corrId, timeout);
         }

--- a/src/modules/producer.js
+++ b/src/modules/producer.js
@@ -182,12 +182,13 @@ class Producer {
         // when the timeout appears.
         if (options.timeout && options.timeout > 0) {
           utils.emitWarn(ARNAVMQ_MSG_TIMEOUT_DEPRECATED);
-          options.expiration = options.timeout;
+          // next line is commented out as we cannot force this breakable change
+          // options.expiration = options.timeout;
         }
         // set expiration if it isn't set yet
-        if (!options.expiration && this._connection.config.rpcTimeout > 0) {
-          options.expiration = this._connection.config.rpcTimeout;
-        }
+        // if (!options.expiration && this._connection.config.rpcTimeout > 0) {
+        //   options.expiration = this._connection.config.rpcTimeout;
+        // }
 
         this.publishOrSendToQueue(queue, msg, options);
         // defered promise that will resolve when response is received

--- a/test/producer-consumer-spec.js
+++ b/test/producer-consumer-spec.js
@@ -162,7 +162,8 @@ describe('producer/consumer', function () {
         });
     });
 
-    it('should not deliver message if timeout is reached ', (done) => {
+    // this test is skipped as corresponding changes were commented out due to breaking effect for services using this lib
+    it.skip('should not deliver message if timeout is reached ', (done) => {
       // (prefetch + 1) messages will be sent. The last one doesn't have to be consumed as it has to be discarded while waiting in the queue
       let receivedCounter = 0;
       const numMsgsToSend = arnavmq.connection._config.prefetch + 1;


### PR DESCRIPTION
revert changes that forced to use options.expiration instead of options.timeout. Expiration is still a preferable option but timeout will continue to work as it did before (with eventual message delivery even if the timeout has reached)