### PR TITLE
Stabilise tests

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,6 +7,7 @@
     "mongo": true
   },
   "rules": {
+    "no-await-in-loop": 0,
     "comma-dangle": 0,
     "max-classes-per-file": 0,
     "max-len": ["error", { "code": 190, "ignoreComments": true, "ignoreUrls": true }],

--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  timeout: 450000,
+  recursive: true,
+  require: 'test/env.js',
+};

--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  timeout: 450000,
+  timeout: 30000,
   recursive: true,
   require: 'test/env.js',
 };

--- a/README.md
+++ b/README.md
@@ -88,44 +88,44 @@ arnavmq.publish('queue:name', { message: 'content' }, { routingKey: 'my-routing-
 You can specify a config object, properties and default values are:
 
 ```javascript
-  const arnavmq = require('arnavmq')({
-    // amqp connection string
-    host: 'amqp://localhost',
+const arnavmq = require('arnavmq')({
+  // amqp connection string
+  host: 'amqp://localhost',
 
-    // number of fetched messages at once on the channel
-    prefetch: 5,
+  // number of fetched messages at once on the channel
+  prefetch: 5,
 
-    // requeue put back message into the broker if consumer crashes/trigger exception
-    requeue: true,
+  // requeue put back message into the broker if consumer crashes/trigger exception
+  requeue: true,
 
-    // time between two reconnect (ms)
-    timeout: 1000,
+  // time between two reconnect (ms)
+  timeout: 1000,
 
-    // the maximum number of retries when trying to send a message before throwing error when failing. If set to '0' will not retry. If set to less then '0', will retry indefinitely.
-    producerMaxRetries: -1,
+  // the maximum number of retries when trying to send a message before throwing error when failing. If set to '0' will not retry. If set to less then '0', will retry indefinitely.
+  producerMaxRetries: -1,
 
-    // default timeout for RPC calls. If set to '0' there will be none.
-    rpcTimeout: 1000,
+  // default timeout for RPC calls. If set to '0' there will be none.
+  rpcTimeout: 1000,
 
-    // suffix all queues names
-    // ex: service-something with suffix :ci becomes service-suffix:ci etc.
-    consumerSuffix: '',
+  // suffix all queues names
+  // ex: service-something with suffix :ci becomes service-suffix:ci etc.
+  consumerSuffix: '',
 
-    // generate a hostname so we can track this connection on the broker (rabbitmq management plugin)
-    hostname: process.env.HOSTNAME || process.env.USER || uuid.v4(),
+  // generate a hostname so we can track this connection on the broker (rabbitmq management plugin)
+  hostname: process.env.HOSTNAME || process.env.USER || uuid.v4(),
 
-    // Deprecated. Use 'logger' instead. The transport to use to debug. If provided, arnavmq will show some logs
-    transport: utils.emptyLogger
+  // Deprecated. Use 'logger' instead. The transport to use to debug. If provided, arnavmq will show some logs
+  transport: utils.emptyLogger,
 
-    /**
-     * A logger object with a log function for each of the log levels ("debug", "info", "warn", or "error").
-     * Each log function receives one parameter containing a log event with the following fields:
-     * * message - A string message describing the event. Always present.
-     * * error - An 'Error' object in case one is present.
-     * * params - An optional object containing extra parameters that can provide extra context for the event.
-     */
-    logger: utils.emptyLogger
-  });
+  /**
+   * A logger object with a log function for each of the log levels ("debug", "info", "warn", or "error").
+   * Each log function receives one parameter containing a log event with the following fields:
+   * * message - A string message describing the event. Always present.
+   * * error - An 'Error' object in case one is present.
+   * * params - An optional object containing extra parameters that can provide extra context for the event.
+   */
+  logger: utils.emptyLogger,
+});
 ```
 
 You can override any or no of the property above.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "main": "src/index.js",
   "scripts": {
-    "lint": "eslint . && prettier -c .",
+    "lint": "eslint . && prettier -c . && dot-only-hunter test",
     "format": "eslint --fix . && prettier --write .",
     "cover": "test -d .nyc_output && nyc report --reporter lcov",
     "test": "nyc mocha --recursive --timeout=30000 --exit"
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "child-process-promise": "^2.2.1",
+    "dot-only-hunter": "^1.0.3",
     "eslint": "^8.25.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-prettier": "^8.6.0",

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
   ],
   "main": "src/index.js",
   "scripts": {
-    "lint": "eslint . && prettier -c . && dot-only-hunter test",
+    "lint": "eslint . && prettier -c .",
     "format": "eslint --fix . && prettier --write .",
     "cover": "test -d .nyc_output && nyc report --reporter lcov",
-    "test": "nyc mocha --recursive --timeout=30000 --exit"
+    "test": "dot-only-hunter test && nyc mocha --recursive --timeout=30000 --exit"
   },
   "prettier": {
     "singleQuote": true,

--- a/src/modules/producer.js
+++ b/src/modules/producer.js
@@ -167,10 +167,11 @@ class Producer {
         // reply to us if you receive this message!
         options.replyTo = this.amqpRPCQueues[queue].queue;
 
-        this.publishOrSendToQueue(queue, msg, options);
         // defered promise that will resolve when response is received
         const responsePromise = pDefer();
         this.amqpRPCQueues[queue][corrId] = responsePromise;
+
+        this.publishOrSendToQueue(queue, msg, options);
 
         //  Using given timeout or default one
         const timeout = options.timeout || this._connection.config.rpcTimeout || 0;

--- a/test/disconnect-spec.js
+++ b/test/disconnect-spec.js
@@ -51,13 +51,14 @@ describe('disconnections', function () {
     it('should retry producing only as configured', async () => {
       const retryCount = 3;
       arnavmq.connection._config.producerMaxRetries = retryCount;
+      arnavmq.connection._config.timeout = 100;
       const expectedError = 'Fake connection error.';
-      sandbox.stub(arnavmq.connection, 'getDefaultChannel').rejects(new Error(expectedError));
+      sandbox.stub(arnavmq.connection, 'get').rejects(new Error(expectedError));
 
       await assert.rejects(
         () => arnavmq.producer.produce(queue),
         (err) => {
-          sinon.assert.callCount(arnavmq.connection.getDefaultChannel, retryCount + 1);
+          sinon.assert.callCount(arnavmq.connection.get, retryCount + 1);
           assert.strictEqual(err.message, expectedError);
           return true;
         }

--- a/test/docker.js
+++ b/test/docker.js
@@ -1,9 +1,64 @@
 const { exec } = require('child-process-promise');
+const utils = require('../src/modules/utils');
 
-const docker = 'docker';
-const containerName = 'arnavmq-tests';
+class Docker {
+  constructor() {
+    this.name = 'arnavmq-tests';
+  }
 
-module.exports.run = () => exec(`${docker} run --detach --name=${containerName} -p 5672:5672 rabbitmq:3.8-alpine`);
-module.exports.start = () => exec(`${docker} start ${containerName}`);
-module.exports.stop = () => exec(`${docker} stop ${containerName}`);
-module.exports.rm = () => exec(`${docker} rm --force --volumes ${containerName} || true`);
+  async start() {
+    // We might be already running, let's cleanup so can a have a fresh start ;)
+    await exec(`docker rm --force --volumes ${this.name} || true`);
+
+    await exec(`docker run --detach --network=bridge --name=${this.name} -p 5672:5672 rabbitmq:3.8-alpine`);
+    await this.waitForReady();
+  }
+
+  /**
+   * Waits for RabbitMQ server to be up & ready with retries
+   */
+  async waitForReady() {
+    let lastErr = null;
+
+    for (let i = 0; i < 20; i += 1) {
+      try {
+        await exec(`docker exec ${this.name} rabbitmqctl status`);
+        return;
+      } catch (err) {
+        lastErr = err;
+        await utils.timeoutPromise(500);
+      }
+    }
+
+    throw new Error(`RabbitMQ health check failed after 20 iterations: ${lastErr.message}`);
+  }
+
+  async isRunning() {
+    try {
+      const res = await exec(`docker container inspect -f '{{.State.Running}}' ${this.name}`);
+      return res.stdout.trim() === 'true';
+    } catch (err) {
+      // We will get an error if container is not runnning.
+      return false;
+    }
+  }
+
+  /**
+   * Disconnect RabbitMQ from network - so we can't access 5672 port.
+   */
+  async disconnectNetwork() {
+    await exec(`docker network disconnect bridge ${this.name}`);
+  }
+
+  /**
+   * Connects RabbitMQ to network
+   *
+   * Should be used after calling "disconnectNetwork"
+   */
+  async connectNetwork() {
+    await exec(`docker network connect bridge ${this.name}`);
+  }
+}
+
+const docker = new Docker();
+module.exports = docker;

--- a/test/docker.js
+++ b/test/docker.js
@@ -60,5 +60,4 @@ class Docker {
   }
 }
 
-const docker = new Docker();
-module.exports = docker;
+module.exports = new Docker();

--- a/test/env.js
+++ b/test/env.js
@@ -1,0 +1,7 @@
+const docker = require('./docker');
+
+exports.mochaHooks = {
+  async beforeAll() {
+    await docker.start();
+  },
+};

--- a/test/producer-consumer-spec.js
+++ b/test/producer-consumer-spec.js
@@ -2,7 +2,6 @@ const assert = require('assert');
 const uuid = require('uuid');
 const arnavmq = require('../src/index')();
 const utils = require('../src/modules/utils');
-const docker = require('./docker');
 
 const fixtures = {
   queues: ['test-queue-0', 'test-queue-1', 'test-queue-2', 'test-queue-3'],
@@ -14,10 +13,7 @@ let letters = 0;
 /* eslint func-names: "off" */
 /* eslint prefer-arrow-callback: "off" */
 describe('producer/consumer', function () {
-  before(docker.rm);
-  before(() => docker.run().then(docker.start));
-
-  describe('msg delevering', () => {
+  describe('msg delivering', () => {
     before(() =>
       arnavmq.consumer
         .consume(fixtures.queues[0], () => {

--- a/test/rpc-spec.js
+++ b/test/rpc-spec.js
@@ -1,17 +1,13 @@
 const assert = require('assert');
 const uuid = require('uuid');
 const arnavmq = require('../src/index')();
-const docker = require('./docker');
 const utils = require('../src/modules/utils');
 
 const fixtures = {
   queues: ['rpc-queue-0', 'rpc-queue-1', 'rpc-queue-2'],
 };
 
-describe('Producer/Consumer RPC messaging:', () => {
-  before(docker.rm);
-  before(() => docker.run().then(docker.start));
-
+describe('Producer/Consumer RPC messaging:', async () => {
   it('should be able to create a consumer that returns a message if called as RPC [rpc-queue-0]', () =>
     arnavmq.consumer
       .consume(fixtures.queues[0], () => 'Power Ranger Red')

--- a/test/rpc-spec.js
+++ b/test/rpc-spec.js
@@ -7,7 +7,7 @@ const fixtures = {
   queues: ['rpc-queue-0', 'rpc-queue-1', 'rpc-queue-2'],
 };
 
-describe('Producer/Consumer RPC messaging:', async () => {
+describe('Producer/Consumer RPC messaging:', () => {
   it('should be able to create a consumer that returns a message if called as RPC [rpc-queue-0]', () =>
     arnavmq.consumer
       .consume(fixtures.queues[0], () => 'Power Ranger Red')


### PR DESCRIPTION
Docker:
* Add health-check to wait for a rabbitmq to be actually up.
* Add way to stop & start network - faster instead of stopping/starting again the docker (heavy process)
* Start docker container only once (and not per-suite) - makes tests
  more stable and run faster.

Disconnect test:
* Re-write to use async/await - more readable
* Wait more properly and have cleaner assertions

Lint:
* add “dot-only-hunter” to catch focused tests.