### PR TITLE
consumer: merge with default options

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arnavmq",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "ArnavMQ is a RabbitMQ wrapper",
   "keywords": [
     "rabbitmq",


### PR DESCRIPTION
Until now when doing subscribe without passing options, we get `durable` & `persistent` queue, now when we pass only `prefetch` - both `durable` & `persistent` won't be applied.
