### PR TITLE
Fix_unhandled_exception

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arnavmq",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "ArnavMQ is a RabbitMQ wrapper",
   "keywords": [
     "rabbitmq",


### PR DESCRIPTION
Fixing a race condition which causes an unhandled promise rejection when the connection is closed before starting to consume from channel.

Added a `.catch` to the `channel.consume(...)` promise, and extracted to separate method since the nesting became a bit nasty.

No need to throw the error outside, since a connection rety would happen already on the channel's 'close` event.

The error was as such:
```
UnhandledPromiseRejectionWarning: IllegalOperationError: Channel closed
    at Channel.<anonymous> (.../node_modules/amqplib/lib/channel.js:160:11)
    at Channel.C.reject (.../node_modules/amqplib/lib/channel_model.js:244:8)
    at .../node_modules/arnavmq/src/modules/consumer.js:92:28
```