### PR TITLE
Convert code to use async/await instead of promise chains.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,6 +11,7 @@
     "comma-dangle": 0,
     "max-classes-per-file": 0,
     "max-len": ["error", { "code": 190, "ignoreComments": true, "ignoreUrls": true }],
-    "no-underscore-dangle": [1, { "allow": ["_config", "_connection", "_maxListeners"], "allowAfterThis": true }]
+    "no-underscore-dangle": [1, { "allow": ["_config", "_connection", "_maxListeners"], "allowAfterThis": true }],
+    "no-return-await": "off"
   }
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -17,3 +17,4 @@
 /.idea/**
 /.github/**
 /samples/**
+.nyc_output/

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   "homepage": "https://github.com/bringg/node-arnavmq#readme",
   "dependencies": {
     "amqplib": "^0.10.3",
-    "p-defer": "^3.0.0",
     "serialize-error": "^8.0.1",
     "uuid": "^9.0.0"
   },
@@ -47,6 +46,7 @@
     "eslint-plugin-import": "^2.26.0",
     "mocha": "^10.0.0",
     "nyc": "^15.1.0",
+    "p-defer": "^3.0.0",
     "prettier": "^2.8.3",
     "sinon": "^15.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "homepage": "https://github.com/bringg/node-arnavmq#readme",
   "dependencies": {
     "amqplib": "^0.10.3",
+    "p-defer": "^3.0.0",
     "serialize-error": "^8.0.1",
     "uuid": "^9.0.0"
   },
@@ -46,7 +47,6 @@
     "eslint-plugin-import": "^2.26.0",
     "mocha": "^10.0.0",
     "nyc": "^15.1.0",
-    "p-defer": "^3.0.0",
     "prettier": "^2.8.3",
     "sinon": "^15.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "eslint . && prettier -c .",
     "format": "eslint --fix . && prettier --write .",
     "cover": "test -d .nyc_output && nyc report --reporter lcov",
-    "test": "dot-only-hunter test && nyc mocha --recursive --timeout=30000 --exit"
+    "test": "dot-only-hunter test && nyc mocha --recursive --exit"
   },
   "prettier": {
     "singleQuote": true,

--- a/src/modules/channels.js
+++ b/src/modules/channels.js
@@ -26,41 +26,41 @@ class Channels {
     this._channels = new Map();
   }
 
-  get(queue, config) {
+  async get(queue, config) {
     // If we don't have custom prefetch create a new channel
     const defaultPrefetch = this._config.prefetch;
     const requestedPrefetch = config.prefetch || defaultPrefetch;
     if (typeof requestedPrefetch === 'number' && requestedPrefetch !== defaultPrefetch) {
-      return this._get(queue, config);
+      return await this._get(queue, config);
     }
 
-    return this.defaultChannel();
+    return await this.defaultChannel();
   }
 
-  defaultChannel() {
-    return this._get(DEFAULT_CHANNEL, { prefetch: this._config.prefetch });
+  async defaultChannel() {
+    return await this._get(DEFAULT_CHANNEL, { prefetch: this._config.prefetch });
   }
 
   /**
    * Creates or returns an existing channel by it's key and config.
    * @return {Promise} A promise that resolve with an amqp.node channel object
    */
-  _get(key, config = {}) {
+  async _get(key, config = {}) {
     const existingChannel = this._channels.get(key);
 
     if (existingChannel) {
       if (!isSameConfig(existingChannel.config, config)) {
-        return Promise.reject(new ChannelAlreadyExistsError(key, config));
+        throw new ChannelAlreadyExistsError(key, config);
       }
 
       // cache handling, if channel already opened, return it
-      return existingChannel.chann;
+      return await existingChannel.chann;
     }
 
     const channelPromise = this._initNewChannel(key, config);
     this._channels.set(key, { chann: channelPromise, config });
 
-    return channelPromise;
+    return await channelPromise;
   }
 
   async _initNewChannel(key, config) {

--- a/src/modules/channels.js
+++ b/src/modules/channels.js
@@ -37,57 +37,68 @@ class Channels {
     return this.defaultChannel();
   }
 
+  defaultChannel() {
+    return this._get(DEFAULT_CHANNEL, { prefetch: this._config.prefetch });
+  }
+
   /**
    * Creates or returns an existing channel by it's key and config.
    * @return {Promise} A promise that resolve with an amqp.node channel object
    */
-  _get(key, config = {}) {
-    let channel = this._channels.get(key);
+  async _get(key, config = {}) {
+    const existingChannel = this._channels.get(key);
 
-    if (channel) {
-      if (!isSameConfig(channel.config, config)) {
+    if (existingChannel) {
+      if (!isSameConfig(existingChannel.config, config)) {
         return Promise.reject(new ChannelAlreadyExistsError(key, config));
       }
 
       // cache handling, if channel already opened, return it
-      return channel.chann;
+      return existingChannel.chann;
     }
 
-    channel = this._connection
-      .createChannel()
-      .then((_channel) => {
-        _channel.prefetch(config.prefetch);
-
-        // on error we remove the channel so the next call will recreate it (auto-reconnect are handled by connection users)
-        _channel.on('close', () => {
-          this._channels.delete(key);
-        });
-        _channel.on('error', (error) => {
-          this._config.logger.error({
-            message: `Got channel error [${error.message}] for [${key}]`,
-            error,
-          });
-        });
-
-        return _channel;
-      })
-      .catch((error) => {
-        this._channels.delete(key);
-        this._config.logger.error({
-          message: `Failed to create channel for [${key}] - [${error.message}]`,
-          error,
-        });
-
-        return Promise.reject(error);
-      });
-
-    this._channels.set(key, { chann: channel, config });
-
-    return channel;
+    return this._initNewChannel(key, config);
   }
 
-  defaultChannel() {
-    return this._get(DEFAULT_CHANNEL, { prefetch: this._config.prefetch });
+  async _initNewChannel(key, config) {
+    let channel;
+    try {
+      channel = await this._connection.createChannel();
+      channel.prefetch(config.prefetch);
+
+      // on error we remove the channel so the next call will recreate it (auto-reconnect are handled by connection users)
+      channel.on('close', () => {
+        this._channels.delete(key);
+      });
+      channel.on('error', (error) => {
+        this._config.logger.error({
+          message: `Got channel error [${error.message}] for [${key}]`,
+          error,
+        });
+      });
+
+      this._channels.set(key, { chann: channel, config });
+      return channel;
+    } catch (error) {
+      this._channels.delete(key);
+      this._config.logger.error({
+        message: `Failed to create channel for [${key}] - [${error.message}]`,
+        error,
+      });
+
+      // Should not happen, but just in case
+      if (channel) {
+        try {
+          await channel.close();
+        } catch (closeError) {
+          this._config.logger.error({
+            message: `Failed to cleanup channel after failed initialization for [${key}] - [${closeError.message}]`,
+            error: closeError,
+          });
+        }
+      }
+      throw error;
+    }
   }
 }
 

--- a/src/modules/connection.js
+++ b/src/modules/connection.js
@@ -16,15 +16,15 @@ class Connection {
    * Connect to the broker. We keep only 1 connection for each connection string provided in config, as advised by RabbitMQ
    * @return {Promise} A promise that resolve with an amqp.node connection object
    */
-  getConnection() {
+  async getConnection() {
     // cache handling, if connection already opened, return it
     if (this._connectionPromise) {
-      return this._connectionPromise;
+      return await this._connectionPromise;
     }
 
     this._connectionPromise = this._connect();
 
-    return this._connectionPromise;
+    return await this._connectionPromise;
   }
 
   async _connect() {
@@ -68,12 +68,12 @@ class Connection {
 
   async getChannel(queue, config) {
     await this.getConnection();
-    return this._channels.get(queue, config);
+    return await this._channels.get(queue, config);
   }
 
   async getDefaultChannel() {
     await this.getConnection();
-    return this._channels.defaultChannel();
+    return await this._channels.defaultChannel();
   }
 
   /**

--- a/src/modules/connection.js
+++ b/src/modules/connection.js
@@ -18,11 +18,9 @@ class Connection {
    */
   async getConnection() {
     // cache handling, if connection already opened, return it
-    if (this._connectionPromise) {
-      return await this._connectionPromise;
+    if (!this._connectionPromise) {
+      this._connectionPromise = this._connect();
     }
-
-    this._connectionPromise = this._connect();
 
     return await this._connectionPromise;
   }

--- a/src/modules/consumer.js
+++ b/src/modules/consumer.js
@@ -40,7 +40,7 @@ class Consumer {
       });
 
       const defaultChannel = await this._connection.getDefaultChannel();
-      return defaultChannel.sendToQueue(messageProperties.replyTo, parsers.out(reply, options), options);
+      return await defaultChannel.sendToQueue(messageProperties.replyTo, parsers.out(reply, options), options);
     }
 
     return messageProperties;
@@ -90,7 +90,7 @@ class Consumer {
     if (!channel) {
       // in case of any error creating the channel, wait for some time and then try to reconnect again (to avoid overflow)
       await utils.timeoutPromise(this._connection.config.timeout);
-      return this.subscribe(queue, options, callback);
+      return await this.subscribe(queue, options, callback);
     }
 
     try {

--- a/src/modules/consumer.js
+++ b/src/modules/consumer.js
@@ -197,6 +197,8 @@ class Consumer {
             params: { queue },
           });
         }
+
+        return;
       }
 
       try {

--- a/src/modules/consumer.js
+++ b/src/modules/consumer.js
@@ -31,7 +31,7 @@ class Consumer {
      * @param  {any} content the received message:
      * @return {any}          object, string, number... the current received message
      */
-    return (content) => {
+    return async (content) => {
       if (msg.properties.replyTo) {
         const options = {
           correlationId: msg.properties.correlationId,
@@ -44,9 +44,8 @@ class Consumer {
           params: { content },
         });
 
-        return this._connection.getDefaultChannel().then((channel) => {
-          return channel.sendToQueue(msg.properties.replyTo, parsers.out(content, options), options);
-        });
+        const defaultChannel = await this._connection.getDefaultChannel();
+        return defaultChannel.sendToQueue(msg.properties.replyTo, parsers.out(content, options), options);
       }
 
       return msg;
@@ -66,7 +65,7 @@ class Consumer {
     return this.subscribe(queue, options, callback);
   }
 
-  subscribe(queue, options, callback) {
+  async subscribe(queue, options, callback) {
     const defaultOptions = {
       persistent: true,
       durable: true,
@@ -93,119 +92,135 @@ class Consumer {
     // ex: service-something with suffix :ci becomes service-suffix:ci etc.
     const suffixedQueue = `${queue}${this._connection.config.consumerSuffix || ''}`;
 
-    return this._connection
-      .getChannel(queue, options.channel || {})
-      .then((channel) => {
-        // when channel is closed, we want to be sure we recreate the queue ASAP so we trigger a reconnect by recreating the consumer
-        channel.addListener('close', () => {
-          this.subscribe(queue, options, callback);
-        });
+    const channel = await this._initializeChannel(queue, options || {}, callback);
+    if (!channel) {
+      // in case of any error creating the channel, wait for some time and then try to reconnect again (to avoid overflow)
+      await utils.timeoutPromise(this._connection.config.timeout);
+      return this.subscribe(queue, options, callback);
+    }
 
-        return channel
-          .assertQueue(suffixedQueue, options)
-          .then((q) => {
-            this._connection.config.transport.debug(loggerAlias, 'init', q.queue);
-            this._connection.config.logger.debug({
-              message: `${loggerAlias} init ${q.queue}`,
-              params: { queue: q.queue },
-            });
-
-            return this._consumeQueue(channel, q.queue, callback);
-          })
-          .catch((error) => {
-            this._connection.config.transport.error(loggerAlias, error);
-            this._connection.config.logger.error({
-              message: `${loggerAlias} Failed to assert queue ${queue}: ${error.message}`,
-              error,
-              params: { queue },
-            });
-          });
-        // in case of any error creating the channel, wait for some time and then try to reconnect again (to avoid overflow)
-      })
-      .catch((err) => {
-        if (err instanceof ChannelAlreadyExistsError) {
-          throw err;
-        } else {
-          return utils
-            .timeoutPromise(this._connection.config.timeout)
-            .then(() => this.subscribe(queue, options, callback));
-        }
+    try {
+      await channel.assertQueue(suffixedQueue, options);
+    } catch (error) {
+      this._connection.config.transport.error(loggerAlias, error);
+      this._connection.config.logger.error({
+        message: `${loggerAlias} Failed to assert queue ${queue}: ${error.message}`,
+        error,
+        params: { queue },
       });
+    }
+
+    this._connection.config.transport.debug(loggerAlias, 'init', queue.queue);
+    this._connection.config.logger.debug({
+      message: `${loggerAlias} init ${queue.queue}`,
+      params: { queue: queue.queue },
+    });
+
+    await this._consumeQueue(channel, queue.queue, callback);
+    return true;
   }
 
-  _consumeQueue(channel, queue, callback) {
-    return channel
-      .consume(
-        queue,
-        (msg) => {
-          if (!msg) {
-            // When forcefully cancelled by rabbitmq, consumer would receive a null message.
-            // https://amqp-node.github.io/amqplib/channel_api.html#channel_consume
-            this._connection.config.transport.warn(loggerAlias, null);
-            this._connection.config.logger.warn({
-              message: `${loggerAlias} Consumer was cancelled by server for queue '${queue}'`,
-              error: null,
-              params: { queue },
-            });
-            return;
-          }
+  async _initializeChannel(queue, options, callback) {
+    let channel;
+    try {
+      channel = await this._connection.getChannel(queue, options.channel || {});
+      // when channel is closed, we want to be sure we recreate the queue ASAP so we trigger a reconnect by recreating the consumer
+      channel.addListener('close', () => {
+        this.subscribe(queue, options, callback);
+      });
+      return channel;
+    } catch (err) {
+      if (err instanceof ChannelAlreadyExistsError) {
+        throw err;
+      }
 
-          const messageString = msg.content.toString();
-          this._connection.config.transport.debug(loggerAlias, `[${queue}] < ${messageString}`);
-          this._connection.config.logger.debug({
-            message: `${loggerAlias} [${queue}] < ${messageString}`,
-            params: { queue, message: messageString },
+      if (channel) {
+        try {
+          // Just in the odd chance the channel was open but the listener failed.
+          await channel.close();
+        } catch (closeError) {
+          this._connection.config.transport.error(loggerAlias, closeError);
+          this._connection.config.logger.error({
+            message: `${loggerAlias} Failed to close channel after initialization error ${queue}: ${closeError.message}`,
+            error: closeError,
+            params: { queue },
           });
+        }
+      }
+      return null;
+    }
+  }
 
-          // main answer management chaining
-          // receive message, parse it, execute callback, check if should answer, ack/reject message
-          Promise.resolve(parsers.in(msg))
-            .then((body) => callback(body, msg.properties))
-            .then(this.checkRpc(msg, queue))
-            .then(() => {
-              try {
-                channel.ack(msg);
-              } catch (ackError) {
-                this._connection.config.transport.error(loggerAlias, ackError);
-                this._connection.config.logger.error({
-                  message: `${loggerAlias} Failed to ack message after processing finished on queue ${queue}: ${ackError.message}`,
-                  error: ackError,
-                  params: { queue },
-                });
-              }
-            })
-            .catch((error) => {
-              // if something bad happened in the callback, reject the message so we can requeue it (or not)
-              this._connection.config.transport.error(loggerAlias, error);
-              this._connection.config.logger.error({
-                message: `${loggerAlias} Failed processing message from queue ${queue}: ${error.message}`,
-                error,
-                params: { queue, message: messageString },
-              });
-
-              try {
-                channel.reject(msg, this._connection.config.requeue);
-              } catch (rejectError) {
-                this._connection.config.transport.error(loggerAlias, rejectError);
-                this._connection.config.logger.error({
-                  message: `${loggerAlias} Failed to reject message after processing failure on queue ${queue}: ${rejectError.message}`,
-                  error: rejectError,
-                  params: { queue },
-                });
-              }
-            });
-        },
-        { noAck: false }
-      )
-      .then(() => true)
-      .catch((error) => {
-        this._connection.config.transport.error(loggerAlias, error);
-        this._connection.config.logger.error({
-          message: `${loggerAlias} Failed to start consuming from queue ${queue}: ${error.message}`,
-          error,
+  async _consumeQueue(channel, queue, callback) {
+    const consumeFunc = async (msg) => {
+      if (!msg) {
+        // When forcefully cancelled by rabbitmq, consumer would receive a null message.
+        // https://amqp-node.github.io/amqplib/channel_api.html#channel_consume
+        this._connection.config.transport.warn(loggerAlias, null);
+        this._connection.config.logger.warn({
+          message: `${loggerAlias} Consumer was cancelled by server for queue '${queue}'`,
+          error: null,
           params: { queue },
         });
+        return;
+      }
+
+      const messageString = msg.content.toString();
+      this._connection.config.transport.debug(loggerAlias, `[${queue}] < ${messageString}`);
+      this._connection.config.logger.debug({
+        message: `${loggerAlias} [${queue}] < ${messageString}`,
+        params: { queue, message: messageString },
       });
+
+      // main answer management chaining
+      // receive message, parse it, execute callback, check if should answer, ack/reject message
+      const body = await Promise.resolve(parsers.in(msg));
+      try {
+        const res = await callback(body, msg.properties);
+        await this.checkRpc(msg, queue)(res);
+      } catch (error) {
+        // if something bad happened in the callback, reject the message so we can requeue it (or not)
+        this._connection.config.transport.error(loggerAlias, error);
+        this._connection.config.logger.error({
+          message: `${loggerAlias} Failed processing message from queue ${queue}: ${error.message}`,
+          error,
+          params: { queue, message: messageString },
+        });
+
+        try {
+          channel.reject(msg, this._connection.config.requeue);
+        } catch (rejectError) {
+          this._connection.config.transport.error(loggerAlias, rejectError);
+          this._connection.config.logger.error({
+            message: `${loggerAlias} Failed to reject message after processing failure on queue ${queue}: ${rejectError.message}`,
+            error: rejectError,
+            params: { queue },
+          });
+        }
+      }
+
+      try {
+        channel.ack(msg);
+      } catch (ackError) {
+        this._connection.config.transport.error(loggerAlias, ackError);
+        this._connection.config.logger.error({
+          message: `${loggerAlias} Failed to ack message after processing finished on queue ${queue}: ${ackError.message}`,
+          error: ackError,
+          params: { queue },
+        });
+      }
+    };
+
+    try {
+      await channel.consume(queue, consumeFunc, { noAck: false });
+    } catch (error) {
+      this._connection.config.transport.error(loggerAlias, error);
+      this._connection.config.logger.error({
+        message: `${loggerAlias} Failed to start consuming from queue ${queue}: ${error.message}`,
+        error,
+        params: { queue },
+      });
+    }
   }
 }
 

--- a/src/modules/consumer.js
+++ b/src/modules/consumer.js
@@ -168,7 +168,7 @@ class Consumer {
 
       // main answer management chaining
       // receive message, parse it, execute callback, check if should answer, ack/reject message
-      const body = await Promise.resolve(parsers.in(msg));
+      const body = parsers.in(msg);
       try {
         const res = await callback(body, msg.properties);
         await this.checkRpc(msg.properties, queue, res);

--- a/src/modules/consumer.js
+++ b/src/modules/consumer.js
@@ -110,13 +110,13 @@ class Consumer {
       });
     }
 
-    this._connection.config.transport.debug(loggerAlias, 'init', queue.queue);
+    this._connection.config.transport.debug(loggerAlias, 'init', queue);
     this._connection.config.logger.debug({
-      message: `${loggerAlias} init ${queue.queue}`,
-      params: { queue: queue.queue },
+      message: `${loggerAlias} init ${queue}`,
+      params: { queue },
     });
 
-    await this._consumeQueue(channel, queue.queue, callback);
+    await this._consumeQueue(channel, queue, callback);
     return true;
   }
 

--- a/src/modules/producer.js
+++ b/src/modules/producer.js
@@ -97,8 +97,8 @@ class Producer {
 
     try {
       const channel = await this._connection.getDefaultChannel();
-      const q = await channel.assertQueue(resQueue, { durable: true, exclusive: true });
-      rpcQueue.queue = q.queue;
+      await channel.assertQueue(resQueue, { durable: true, exclusive: true });
+      rpcQueue.queue = resQueue;
 
       // if channel is closed, we want to make sure we cleanup the queue so future calls will recreate it
       this._connection.addListener('close', () => {
@@ -106,7 +106,7 @@ class Producer {
         this.createRpcQueue(queue);
       });
 
-      await channel.consume(q.queue, this.maybeAnswer(queue), {
+      await channel.consume(resQueue, this.maybeAnswer(queue), {
         noAck: true,
       });
       return rpcQueue.queue;

--- a/test/disconnect-spec.js
+++ b/test/disconnect-spec.js
@@ -95,7 +95,7 @@ describe('disconnections', function () {
 
       assert.equal(
         responses,
-        Array.from({ length: 50 }, (_, i) => i + 1)
+        Array.from({ length: 49 }, (_, i) => i + 2)
       );
       assert.equal(counter, 50, `consumer counter should be 50, but it is ${counter}`);
     });

--- a/test/disconnect-spec.js
+++ b/test/disconnect-spec.js
@@ -90,12 +90,14 @@ describe('disconnections', function () {
       }
 
       await docker.connectNetwork();
-      let responses = await Promise.all(producePromises);
-      responses = responses.sort((a, b) => a - b);
+      const responses = await Promise.all(producePromises);
+      responses.sort((a, b) => a - b);
 
-      const lastResponse = responses[responses.length - 1];
-      assert.equal(lastResponse, 50, 'last response should be 50');
-      assert.equal(counter, 50, 'consumer counter should be 50');
+      assert.equal(
+        responses,
+        Array.from({ length: 50 }, (_, i) => i + 1)
+      );
+      assert.equal(counter, 50, `consumer counter should be 50, but it is ${counter}`);
     });
   });
 });

--- a/test/disconnect-spec.js
+++ b/test/disconnect-spec.js
@@ -80,7 +80,7 @@ describe('disconnections', function () {
 
       await arnavmq.producer.produce(queue, undefined, { rpc: true });
       await utils.timeoutPromise(500);
-      assert.equal(counter, 1);
+      assert.strictEqual(counter, 1);
 
       await docker.disconnectNetwork();
 
@@ -93,11 +93,11 @@ describe('disconnections', function () {
       const responses = await Promise.all(producePromises);
       responses.sort((a, b) => a - b);
 
-      assert.equal(
+      assert.deepStrictEqual(
         responses,
         Array.from({ length: 49 }, (_, i) => i + 2)
       );
-      assert.equal(counter, 50, `consumer counter should be 50, but it is ${counter}`);
+      assert.strictEqual(counter, 50, `consumer counter should be 50, but it is ${counter}`);
     });
   });
 });

--- a/test/producer-consumer-spec.js
+++ b/test/producer-consumer-spec.js
@@ -283,35 +283,30 @@ describe('producer/consumer', function () {
   });
 
   describe('rpc timeouts', () => {
-    it('should reject on timeout, if no answer received', (done) => {
-      arnavmq.producer
-        .produce('non-existing-queue', { msg: 'ok' }, { rpc: true, timeout: 1000 })
-        .then(() => {
-          assert.fail('Did not get the expected error.');
-        })
-        .catch((e) => {
-          if (e instanceof assert.AssertionError) {
-            throw e;
-          }
-          assert.equal(e.message, 'Timeout reached');
-          done();
-        });
+    it('should reject on timeout, if no answer received', async () => {
+      try {
+        await arnavmq.producer.produce('non-existing-queue', { msg: 'ok' }, { rpc: true, timeout: 1000 });
+        assert.fail('Did not get the expected error.');
+      } catch (error) {
+        if (error instanceof assert.AssertionError) {
+          throw error;
+        }
+        assert.equal(error.message, 'Timeout reached');
+      }
     });
 
-    it('should reject on default timeout, if no answer received', () => {
+    it('should reject on default timeout, if no answer received', async () => {
       arnavmq.connection._config.rpcTimeout = 1000;
-      arnavmq.producer
-        .produce('non-existing-queue', { msg: 'ok' }, { rpc: true })
-        .then(() => {
-          assert.fail('Did not get the expected error.');
-        })
-        .catch((e) => {
-          if (e instanceof assert.AssertionError) {
-            throw e;
-          }
+      try {
+        await arnavmq.producer.produce('non-existing-queue', { msg: 'ok' }, { rpc: true });
+        assert.fail('Did not get the expected error.');
+      } catch (error) {
+        if (error instanceof assert.AssertionError) {
+          throw error;
+        }
 
-          assert.equal(e.message, 'Timeout reached');
-        });
+        assert.equal(error.message, 'Timeout reached');
+      }
     });
   });
 

--- a/test/producer-consumer-spec.js
+++ b/test/producer-consumer-spec.js
@@ -253,7 +253,7 @@ describe('producer/consumer', function () {
           }
           throw new Error('Any kind of error');
         })
-        .then(() => arnavmq.producer.produce(fixtures.queues[3], { msg: uuid.v4() }))
+        .then(() => arnavmq.producer.produce(fixtures.queues[4], { msg: uuid.v4() }))
         .then((response) => {
           assert(response === true);
           letters += 1;

--- a/test/producer-consumer-spec.js
+++ b/test/producer-consumer-spec.js
@@ -6,7 +6,7 @@ const utils = require('../src/modules/utils');
 const { Channels, ChannelAlreadyExistsError } = require('../src/modules/channels');
 
 const fixtures = {
-  queues: ['test-queue-0', 'test-queue-1', 'test-queue-2', 'test-queue-3'],
+  queues: ['test-queue-0', 'test-queue-1', 'test-queue-2', 'test-queue-3', 'test-queue-4'],
   routingKey: 'queue-routing-key',
 };
 
@@ -239,16 +239,17 @@ describe('producer/consumer', function () {
   });
 
   describe('msg requeueing', () => {
-    it('should requeue the message again on error [test-queue-0]', (done) => {
+    it('should requeue the message again on error [test-queue-4]', (done) => {
       let attempt = 3;
 
       arnavmq.consumer
-        .consume(fixtures.queues[3], (msg) => {
+        .consume(fixtures.queues[4], (msg) => {
           assert(typeof msg === 'object');
 
           attempt -= 1;
-          if (!attempt) {
-            return done();
+          if (attempt === 0) {
+            done();
+            return;
           }
           throw new Error('Any kind of error');
         })

--- a/test/producer-consumer-spec.js
+++ b/test/producer-consumer-spec.js
@@ -120,111 +120,108 @@ describe('producer/consumer', function () {
   });
 
   describe('msg delivering', () => {
-    before(() =>
-      arnavmq.consumer
-        .consume(fixtures.queues[0], () => {
-          letters -= 1;
-        })
-        .then(() =>
-          arnavmq.consumer.consume(fixtures.queues[1], () => {
-            letters -= 1;
-          })
-        )
-    );
+    before(async () => {
+      await arnavmq.consumer.consume(fixtures.queues[0], () => {
+        letters -= 1;
+      });
 
-    it('should receive message that is only string', () => {
+      await arnavmq.consumer.consume(fixtures.queues[1], () => {
+        letters -= 1;
+      });
+    });
+
+    it('should receive message that is only string', async () => {
       const queueName = 'test-only-string-queue';
-      return arnavmq.consumer
-        .consume(queueName, (message) => Promise.resolve(`${message}-test`))
-        .then(() => arnavmq.producer.produce(queueName, '85.69.30.121', { rpc: true }))
-        .then((result) => {
-          assert.equal(result, '85.69.30.121-test');
-        });
+
+      await arnavmq.consumer.consume(queueName, (message) => Promise.resolve(`${message}-test`));
+      const result = await arnavmq.producer.produce(queueName, '85.69.30.121', { rpc: true });
+
+      assert.equal(result, '85.69.30.121-test');
     });
 
-    it('should receive message that is only array', () => {
+    it('should receive message that is only array', async () => {
       const queueName = 'test-only-array-queue';
-      return arnavmq.consumer
-        .consume(queueName, (message) => Promise.resolve({ message }))
-        .then(() => arnavmq.producer.produce(queueName, [1, '2'], { rpc: true }))
-        .then((result) => {
-          assert.deepEqual(result, { message: [1, '2'] });
-        });
+
+      await arnavmq.consumer.consume(queueName, (message) => Promise.resolve({ message }));
+      const result = await arnavmq.producer.produce(queueName, [1, '2'], { rpc: true });
+
+      assert.deepEqual(result, { message: [1, '2'] });
     });
 
-    it('should receive message headers', () => {
+    it('should receive message headers', async () => {
       const headers = { header1: 'Header1', header2: 'Header2' };
       const queueName = 'test-headers';
-      return arnavmq.consumer
-        .consume(queueName, (message, properties) => Promise.resolve({ message, properties }))
-        .then(() => arnavmq.producer.produce(queueName, [1, '2'], { rpc: true, headers }))
-        .then((result) => {
-          assert.deepEqual(result.message, [1, '2']);
-          assert.deepEqual(result.properties.headers, headers);
-        });
+
+      await arnavmq.consumer.consume(queueName, (message, properties) => Promise.resolve({ message, properties }));
+      const result = await arnavmq.producer.produce(queueName, [1, '2'], { rpc: true, headers });
+
+      assert.deepEqual(result.message, [1, '2']);
+      assert.deepEqual(result.properties.headers, headers);
     });
 
-    it('should receive message properties', () => {
+    it('should receive message properties', async () => {
       const queueName = 'test-headers';
-      return arnavmq.consumer
-        .consume(queueName, (message, properties) => Promise.resolve({ message, properties }))
-        .then(() => arnavmq.producer.produce(queueName, [1, '2'], { rpc: true }))
-        .then((result) => {
-          assert.deepEqual(result.message, [1, '2']);
-          assert.deepEqual(result.properties.contentType, 'application/json');
-        });
+
+      await arnavmq.consumer.consume(queueName, (message, properties) => Promise.resolve({ message, properties }));
+      const result = await arnavmq.producer.produce(queueName, [1, '2'], { rpc: true });
+
+      assert.deepEqual(result.message, [1, '2']);
+      assert.deepEqual(result.properties.contentType, 'application/json');
     });
 
-    it('should receive contentLength property', () => {
+    it('should receive contentLength property', async () => {
       const queueName = 'test-headers';
       const payload = { a: 1 };
       const messageSize = Buffer.byteLength(JSON.stringify(payload));
-      return arnavmq.consumer
-        .consume(queueName, (message, properties) => Promise.resolve({ message, properties }))
-        .then(() => arnavmq.producer.produce(queueName, payload, { rpc: true }))
-        .then((result) => {
-          assert.deepEqual(result.message, payload);
-          assert.deepEqual(result.properties.contentType, 'application/json');
-          assert.deepEqual(result.properties.contentLength, messageSize);
-        });
+
+      await arnavmq.consumer.consume(queueName, (message, properties) => Promise.resolve({ message, properties }));
+      const result = await arnavmq.producer.produce(queueName, payload, { rpc: true });
+
+      assert.deepEqual(result.message, payload);
+      assert.deepEqual(result.properties.contentType, 'application/json');
+      assert.deepEqual(result.properties.contentLength, messageSize);
     });
 
-    it('should be able to consume message sent by producer to queue [test-queue-0]', () => {
+    it('should be able to consume message sent by producer to queue [test-queue-0]', async () => {
       letters += 1;
-      return arnavmq.producer
-        .produce(fixtures.queues[0], { msg: uuid.v4() })
-        .then(() => utils.timeoutPromise(300))
-        .then(() => assert.equal(letters, 0));
+
+      await arnavmq.producer.produce(fixtures.queues[0], { msg: uuid.v4() });
+      await utils.timeoutPromise(300);
+
+      assert.equal(letters, 0);
     });
 
-    it('should be able to consume message sent by producer to queue [test-queue-0] (no message)', () => {
+    it('should be able to consume message sent by producer to queue [test-queue-0] (no message)', async () => {
       letters += 1;
-      return arnavmq.producer
-        .produce(fixtures.queues[0])
-        .then(() => utils.timeoutPromise(300))
-        .then(() => assert.equal(letters, 0));
+
+      await arnavmq.producer.produce(fixtures.queues[0]);
+      await utils.timeoutPromise(300);
+
+      assert.equal(letters, 0);
     });
 
-    it('should be able to consume message sent by producer to queue [test-queue-0] (null message)', () => {
+    it('should be able to consume message sent by producer to queue [test-queue-0] (null message)', async () => {
       letters += 1;
-      return arnavmq.producer
-        .produce(fixtures.queues[0], null)
-        .then(() => utils.timeoutPromise(300))
-        .then(() => assert.equal(letters, 0));
+
+      await arnavmq.producer.produce(fixtures.queues[0], null);
+      await utils.timeoutPromise(300);
+
+      assert.equal(letters, 0);
     });
 
-    it('should not be able to consume message sent by producer to queue [test-queue-1]', () => {
+    it('should not be able to consume message sent by producer to queue [test-queue-1]', async () => {
       letters += 1;
-      return arnavmq.producer
-        .produce(fixtures.queues[1], null)
-        .then(() => utils.timeoutPromise(300))
-        .then(() => assert.equal(letters, 0));
+
+      await arnavmq.producer.produce(fixtures.queues[1], null);
+      await utils.timeoutPromise(300);
+
+      assert.equal(letters, 0);
     });
 
     it(
       'should be able to consume all message populated by producer to all queues [test-queue-0,' +
         ' test-queue-1, test-queue-2]',
-      () => {
+      async () => {
         const count = 100;
         const messages = [];
         letters += 200;
@@ -233,10 +230,10 @@ describe('producer/consumer', function () {
           messages.push(arnavmq.producer.produce(fixtures.queues[0], null));
           messages.push(arnavmq.producer.produce(fixtures.queues[1], null));
         }
+        await Promise.all(messages);
+        await utils.timeoutPromise(500);
 
-        return Promise.all(messages)
-          .then(() => utils.timeoutPromise(500))
-          .then(() => assert.equal(letters, 0));
+        assert.equal(letters, 0);
       }
     );
   });
@@ -255,36 +252,65 @@ describe('producer/consumer', function () {
           }
           throw new Error('Any kind of error');
         })
-        .then(() =>
-          arnavmq.producer.produce(fixtures.queues[3], { msg: uuid.v4() }).then((response) => {
-            assert(response === true);
-            letters += 1;
-          })
-        )
+        .then(() => arnavmq.producer.produce(fixtures.queues[3], { msg: uuid.v4() }))
+        .then((response) => {
+          assert(response === true);
+          letters += 1;
+        })
         .catch(done);
     });
   });
 
   describe('routing keys', () => {
-    it('should be able to send a message to a rounting key exchange', () =>
+    it('should be able to send a message to a routing key exchange', (done) => {
       arnavmq.consumer
-        .consume(fixtures.routingKey, (message) => {
-          assert.equal(message.content, 'ok');
-        })
-        .then(() => arnavmq.producer.produce(fixtures.rountingKey, { content: 'ok' }, { routingKey: 'route' })));
+        .consume(
+          fixtures.routingKey,
+          (message) => {
+            try {
+              assert.equal(message.content, 'ok');
+              done();
+            } catch (error) {
+              done(error);
+            }
+          },
+          {}
+        )
+        .then(() => arnavmq.producer.produce('', { content: 'ok' }, { routingKey: fixtures.routingKey }))
+        .catch(done);
+    });
   });
 
   describe('rpc timeouts', () => {
-    it('should reject on timeout, if no answer received', () =>
-      arnavmq.producer.produce('non-existing-queue', { msg: 'ok' }, { rpc: true, timeout: 1000 }).catch((e) => {
-        assert.equal(e.message, 'Timeout reached');
-      }));
+    it('should reject on timeout, if no answer received', (done) => {
+      arnavmq.producer
+        .produce('non-existing-queue', { msg: 'ok' }, { rpc: true, timeout: 1000 })
+        .then(() => {
+          assert.fail('Did not get the expected error.');
+        })
+        .catch((e) => {
+          if (e instanceof assert.AssertionError) {
+            throw e;
+          }
+          assert.equal(e.message, 'Timeout reached');
+          done();
+        });
+    });
 
     it('should reject on default timeout, if no answer received', () => {
       arnavmq.connection._config.rpcTimeout = 1000;
-      arnavmq.producer.produce('non-existing-queue', { msg: 'ok' }, { rpc: true }).catch((e) => {
-        assert.equal(e.message, 'Timeout reached');
-      });
+      arnavmq.producer
+        .produce('non-existing-queue', { msg: 'ok' }, { rpc: true })
+        .then(() => {
+          assert.fail('Did not get the expected error.');
+        })
+        .catch((e) => {
+          if (e instanceof assert.AssertionError) {
+            throw e;
+          }
+
+          assert.equal(e.message, 'Timeout reached');
+        });
     });
   });
 
@@ -307,10 +333,15 @@ describe('producer/consumer', function () {
       arnavmq.connection._config.consumerSuffix = undefined;
     });
 
-    it('should receive message', () => {
+    it('should receive message', (done) => {
       arnavmq.consumer
         .consume('queue-name-undefined-suffix', (message) => {
-          assert.equal(message.msg, 'test for undefined queue suffix');
+          try {
+            assert.equal(message.msg, 'test for undefined queue suffix');
+            done();
+          } catch (error) {
+            done(error);
+          }
         })
         .then(() =>
           arnavmq.producer.produce('queue-name-undefined-suffix', {

--- a/test/rpc-spec.js
+++ b/test/rpc-spec.js
@@ -59,7 +59,7 @@ describe('Producer/Consumer RPC messaging:', () => {
       await arnavmq.producer.produce(fixtures.queues[3], undefined, {
         contentType: 'application/json',
         rpc: true,
-        timeout: 500,
+        timeout: 5000,
       });
       assert.fail('Did not get the expected error.');
     } catch (error) {
@@ -67,7 +67,7 @@ describe('Producer/Consumer RPC messaging:', () => {
         throw error;
       }
 
-      assert.strictEqual(error.name, 'SyntaxError');
+      assert.strictEqual(error.name, 'SyntaxError', `Got unexpected error of type ' ${error.name}': ${error.message}`);
     }
   });
 });


### PR DESCRIPTION
* Replaced all promise chains with `async/await` calls.
* Cleaned up, extracted functions, and added more `try/catch` blocks where needed.
* Made tests more async and fixed them where needed.
  * Some of the tests which tested pub/sub didn't actually wait for the result, so they were practically skipped. Changed them to be finished only when the pub/sub was finished without errors.