### PR TITLE
Change default channel to string.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arnavmq",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "ArnavMQ is a RabbitMQ wrapper",
   "keywords": [
     "rabbitmq",

--- a/src/modules/channels.js
+++ b/src/modules/channels.js
@@ -1,4 +1,4 @@
-const DEFAULT_CHANNEL = Symbol('DEFAULT_CHANNEL');
+const DEFAULT_CHANNEL = 'DEFAULT_CHANNEL';
 
 class ChannelAlreadyExistsError extends Error {
   constructor(name, config) {


### PR DESCRIPTION
In order to avoid needing to explicitly convert it to string for logging.

This is instead of https://github.com/bringg/node-arnavmq/pull/59