### PR TITLE
Clear rpc timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arnavmq",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "ArnavMQ is a RabbitMQ wrapper",
   "keywords": [
     "rabbitmq",


### PR DESCRIPTION
Just clean the `setTimeout` we are doing for rpc in-case we already
received the message before the timeout.
