### PR TITLE
ci: test with node 20 & drop node 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
 
     - uses: actions/setup-node@v3
       with:
-        node-version: 14.x
+        node-version: 20.x
         registry-url: https://registry.npmjs.org
 
     - run: npm publish --access public


### PR DESCRIPTION
- Test with Node 20 which is current LTS
- Drop Node 14 since it's EOL

We will still test on Node.js 16, since we haven't migrated off it yet.