### PR TITLE
Add more useful type exports.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arnavmq",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "ArnavMQ is a RabbitMQ wrapper",
   "keywords": [
     "rabbitmq",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -16,7 +16,8 @@ import arnavmq = require('./modules/arnavmq');
 declare function arnavmqFactory(config: ConnectionConfig): arnavmq.Arnavmq;
 
 declare namespace arnavmqFactory {
-  export type ArnavmqFactory = (config: ConnectionConfig) => arnavmq.Arnavmq;
+  export type Arnavmq = arnavmq.Arnavmq;
+  export type ArnavmqFactory = (config: ConnectionConfig) => Arnavmq;
 
   export { ConnectionConfig, Connection, Consumer, Producer, ConnectionHooks, ConsumerHooks, ProducerHooks };
 }

--- a/types/modules/consumer.d.ts
+++ b/types/modules/consumer.d.ts
@@ -60,4 +60,8 @@ declare class Consumer {
   ): Promise<void>;
 }
 
+declare namespace Consumer {
+  export { ConsumeOptions, ConsumeCallback };
+}
+
 export = Consumer;

--- a/types/modules/producer.d.ts
+++ b/types/modules/producer.d.ts
@@ -7,7 +7,7 @@ declare class ProducerError extends Error {
   constructor(error: { name: string; message: string });
 }
 
-interface PublishOptions extends amqp.Options.Publish {
+interface ProduceOptions extends amqp.Options.Publish {
   routingKey?: string;
   rpc?: boolean;
 }
@@ -45,7 +45,7 @@ declare class Producer {
    * @param msg The message to publish
    * @param options The publish options
    */
-  publishOrSendToQueue(queue: string, msg: Buffer, options: PublishOptions): Promise<boolean>;
+  publishOrSendToQueue(queue: string, msg: Buffer, options: ProduceOptions): Promise<boolean>;
   /**
    * Start a timer to reject the pending RPC call if no answer is received within the given timeout
    * @param queue  The queue where the RPC request was sent
@@ -61,7 +61,7 @@ declare class Producer {
    * @param options contain rpc property (if true, enable rpc for this message)
    * @return Resolves when message is correctly sent, or when response is received when rpc is enabled
    */
-  private checkRpc(queue: string, msg: Buffer, options: PublishOptions): Promise<boolean>;
+  private checkRpc(queue: string, msg: Buffer, options: ProduceOptions): Promise<boolean>;
   /**
    * @deprecated Use publish instead
    * Ensure channel exists and send message using `checkRpc`
@@ -70,18 +70,22 @@ declare class Producer {
    * @param options message options (persistent, durable, rpc, etc.)
    * @return checkRpc response
    */
-  produce(queue: string, msg: unknown, options: PublishOptions): Promise<unknown>;
+  produce(queue: string, msg: unknown, options: ProduceOptions): Promise<unknown>;
   /** @see Producer.produce */
-  publish(queue: string, msg: unknown, options: PublishOptions): Promise<unknown>;
+  publish(queue: string, msg: unknown, options: ProduceOptions): Promise<unknown>;
 
   private _sendToQueue(
     queue: string,
     message: unknown,
-    settings: PublishOptions,
+    settings: ProduceOptions,
     currentRetryNumber: number,
   ): Promise<unknown>;
 
   private _shouldRetry(error: Error | ProducerError, currentRetryNumber: number): boolean;
+}
+
+declare namespace Producer {
+  export { ProduceOptions, ProducerError };
 }
 
 export = Producer;

--- a/types/modules/producer.d.ts
+++ b/types/modules/producer.d.ts
@@ -45,7 +45,7 @@ declare class Producer {
    * @param msg The message to publish
    * @param options The publish options
    */
-  publishOrSendToQueue(queue: string, msg: Buffer, options: ProduceOptions): Promise<boolean>;
+  private publishOrSendToQueue(queue: string, msg: Buffer, options: ProduceOptions): Promise<boolean>;
   /**
    * Start a timer to reject the pending RPC call if no answer is received within the given timeout
    * @param queue  The queue where the RPC request was sent


### PR DESCRIPTION
The argument type for the produce and consume functions were not exported, and so was the type of the `Arnavmq` object itself.