### PR TITLE
Copy required types from @types/amqplib

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arnavmq",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "ArnavMQ is a RabbitMQ wrapper",
   "keywords": [
     "rabbitmq",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "uuid": "^9.0.0"
   },
   "devDependencies": {
-    "@types/amqplib": "^0.10.5",
+    "@types/node": "^20.11.30",
     "child-process-promise": "^2.2.1",
     "dot-only-hunter": "^1.0.3",
     "eslint": "^8.25.0",

--- a/types/modules/amqp.d.ts
+++ b/types/modules/amqp.d.ts
@@ -1,0 +1,303 @@
+// This file contains some types copied directly from the @types/amqplib@0.10.5 package, in order to remove the package from the dev-dependencies of projects depending on node-arnavmq.
+// When using the types directly, builds depending on this package would also potentially require @types/amqplib to compile.
+// The @types/amqplib@0.10.5 uses MIT license, same as this project.
+
+import events = require('events');
+
+interface AmqpChannel extends events.EventEmitter {
+  connection: AmqpConnection;
+
+  close(): Promise<void>;
+
+  assertQueue(queue: string, options?: AmqpOptions.AssertQueue): Promise<Replies.AssertQueue>;
+  checkQueue(queue: string): Promise<Replies.AssertQueue>;
+
+  deleteQueue(queue: string, options?: AmqpOptions.DeleteQueue): Promise<Replies.DeleteQueue>;
+  purgeQueue(queue: string): Promise<Replies.PurgeQueue>;
+
+  bindQueue(queue: string, source: string, pattern: string, args?: any): Promise<Replies.Empty>;
+  unbindQueue(queue: string, source: string, pattern: string, args?: any): Promise<Replies.Empty>;
+
+  assertExchange(
+    exchange: string,
+    type: 'direct' | 'topic' | 'headers' | 'fanout' | 'match' | string,
+    options?: AmqpOptions.AssertExchange,
+  ): Promise<Replies.AssertExchange>;
+  checkExchange(exchange: string): Promise<Replies.Empty>;
+
+  deleteExchange(exchange: string, options?: AmqpOptions.DeleteExchange): Promise<Replies.Empty>;
+
+  bindExchange(destination: string, source: string, pattern: string, args?: any): Promise<Replies.Empty>;
+  unbindExchange(destination: string, source: string, pattern: string, args?: any): Promise<Replies.Empty>;
+
+  publish(exchange: string, routingKey: string, content: Buffer, options?: AmqpOptions.Publish): boolean;
+  sendToQueue(queue: string, content: Buffer, options?: AmqpOptions.Publish): boolean;
+
+  consume(
+    queue: string,
+    onMessage: (msg: ConsumeMessage | null) => void,
+    options?: AmqpOptions.Consume,
+  ): Promise<Replies.Consume>;
+
+  cancel(consumerTag: string): Promise<Replies.Empty>;
+  get(queue: string, options?: AmqpOptions.Get): Promise<GetMessage | false>;
+
+  ack(message: AmqpMessage, allUpTo?: boolean): void;
+  ackAll(): void;
+
+  nack(message: AmqpMessage, allUpTo?: boolean, requeue?: boolean): void;
+  nackAll(requeue?: boolean): void;
+  reject(message: AmqpMessage, requeue?: boolean): void;
+
+  prefetch(count: number, global?: boolean): Promise<Replies.Empty>;
+  recover(): Promise<Replies.Empty>;
+}
+
+interface AmqpConnection extends events.EventEmitter {
+  close(): Promise<void>;
+  createChannel(): Promise<AmqpChannel>;
+  createConfirmChannel(): Promise<AmqpConfirmChannel>;
+  connection: {
+    serverProperties: ServerProperties;
+  };
+}
+
+export namespace Replies {
+  interface Empty {}
+  interface AssertQueue {
+    queue: string;
+    messageCount: number;
+    consumerCount: number;
+  }
+  interface PurgeQueue {
+    messageCount: number;
+  }
+  interface DeleteQueue {
+    messageCount: number;
+  }
+  interface AssertExchange {
+    exchange: string;
+  }
+  interface Consume {
+    consumerTag: string;
+  }
+}
+
+export namespace AmqpOptions {
+  interface Connect {
+    /**
+     * The to be used protocol
+     *
+     * Default value: 'amqp'
+     */
+    protocol?: string | undefined;
+    /**
+     * Hostname used for connecting to the server.
+     *
+     * Default value: 'localhost'
+     */
+    hostname?: string | undefined;
+    /**
+     * Port used for connecting to the server.
+     *
+     * Default value: 5672
+     */
+    port?: number | undefined;
+    /**
+     * Username used for authenticating against the server.
+     *
+     * Default value: 'guest'
+     */
+    username?: string | undefined;
+    /**
+     * Password used for authenticating against the server.
+     *
+     * Default value: 'guest'
+     */
+    password?: string | undefined;
+    /**
+     * The desired locale for error messages. RabbitMQ only ever uses en_US
+     *
+     * Default value: 'en_US'
+     */
+    locale?: string | undefined;
+    /**
+     * The size in bytes of the maximum frame allowed over the connection. 0 means
+     * no limit (but since frames have a size field which is an unsigned 32 bit integer, it’s perforce 2^32 - 1).
+     *
+     * Default value: 0x1000 (4kb) - That's the allowed minimum, it will fit many purposes
+     */
+    frameMax?: number | undefined;
+    /**
+     * The period of the connection heartbeat in seconds.
+     *
+     * Default value: 0
+     */
+    heartbeat?: number | undefined;
+    /**
+     * What VHost shall be used.
+     *
+     * Default value: '/'
+     */
+    vhost?: string | undefined;
+  }
+
+  interface AssertQueue {
+    exclusive?: boolean | undefined;
+    durable?: boolean | undefined;
+    autoDelete?: boolean | undefined;
+    arguments?: any;
+    messageTtl?: number | undefined;
+    expires?: number | undefined;
+    deadLetterExchange?: string | undefined;
+    deadLetterRoutingKey?: string | undefined;
+    maxLength?: number | undefined;
+    maxPriority?: number | undefined;
+  }
+  interface DeleteQueue {
+    ifUnused?: boolean | undefined;
+    ifEmpty?: boolean | undefined;
+  }
+  interface AssertExchange {
+    durable?: boolean | undefined;
+    internal?: boolean | undefined;
+    autoDelete?: boolean | undefined;
+    alternateExchange?: string | undefined;
+    arguments?: any;
+  }
+  interface DeleteExchange {
+    ifUnused?: boolean | undefined;
+  }
+  interface Publish {
+    expiration?: string | number | undefined;
+    userId?: string | undefined;
+    CC?: string | string[] | undefined;
+
+    mandatory?: boolean | undefined;
+    persistent?: boolean | undefined;
+    deliveryMode?: boolean | number | undefined;
+    BCC?: string | string[] | undefined;
+
+    contentType?: string | undefined;
+    contentEncoding?: string | undefined;
+    headers?: any;
+    priority?: number | undefined;
+    correlationId?: string | undefined;
+    replyTo?: string | undefined;
+    messageId?: string | undefined;
+    timestamp?: number | undefined;
+    type?: string | undefined;
+    appId?: string | undefined;
+  }
+  interface Consume {
+    consumerTag?: string | undefined;
+    noLocal?: boolean | undefined;
+    noAck?: boolean | undefined;
+    exclusive?: boolean | undefined;
+    priority?: number | undefined;
+    arguments?: any;
+  }
+  interface Get {
+    noAck?: boolean | undefined;
+  }
+}
+
+export interface AmqpMessage {
+  content: Buffer;
+  fields: MessageFields;
+  properties: AmqpMessageProperties;
+}
+
+export interface GetMessage extends AmqpMessage {
+  fields: GetMessageFields;
+}
+
+export interface ConsumeMessage extends AmqpMessage {
+  fields: ConsumeMessageFields;
+}
+
+export interface CommonMessageFields {
+  deliveryTag: number;
+  redelivered: boolean;
+  exchange: string;
+  routingKey: string;
+}
+
+export interface MessageFields extends CommonMessageFields {
+  messageCount?: number | undefined;
+  consumerTag?: string | undefined;
+}
+
+export interface GetMessageFields extends CommonMessageFields {
+  messageCount: number;
+}
+
+export interface ConsumeMessageFields extends CommonMessageFields {
+  consumerTag: string;
+}
+
+export interface AmqpMessageProperties {
+  contentType: any | undefined;
+  contentEncoding: any | undefined;
+  headers: MessagePropertyHeaders | undefined;
+  deliveryMode: any | undefined;
+  priority: any | undefined;
+  correlationId: any | undefined;
+  replyTo: any | undefined;
+  expiration: any | undefined;
+  messageId: any | undefined;
+  timestamp: any | undefined;
+  type: any | undefined;
+  userId: any | undefined;
+  appId: any | undefined;
+  clusterId: any | undefined;
+}
+
+export interface MessagePropertyHeaders {
+  'x-first-death-exchange'?: string | undefined;
+  'x-first-death-queue'?: string | undefined;
+  'x-first-death-reason'?: string | undefined;
+  'x-death'?: XDeath[] | undefined;
+  [key: string]: any;
+}
+
+export interface XDeath {
+  count: number;
+  reason: 'rejected' | 'expired' | 'maxlen';
+  queue: string;
+  time: {
+    '!': 'timestamp';
+    value: number;
+  };
+  exchange: string;
+  'original-expiration'?: any;
+  'routing-keys': string[];
+}
+
+export interface ServerProperties {
+  host: string;
+  product: string;
+  version: string;
+  platform: string;
+  copyright?: string | undefined;
+  information: string;
+  [key: string]: string | undefined;
+}
+
+interface AmqpConfirmChannel extends AmqpChannel {
+  publish(
+    exchange: string,
+    routingKey: string,
+    content: Buffer,
+    options?: AmqpOptions.Publish,
+    callback?: (err: any, ok: Replies.Empty) => void,
+  ): boolean;
+  sendToQueue(
+    queue: string,
+    content: Buffer,
+    options?: AmqpOptions.Publish,
+    callback?: (err: any, ok: Replies.Empty) => void,
+  ): boolean;
+
+  waitForConfirms(): Promise<void>;
+}

--- a/types/modules/channels.d.ts
+++ b/types/modules/channels.d.ts
@@ -1,22 +1,22 @@
-import type amqp = require('amqplib');
+import { AmqpChannel, AmqpConnection } from './amqp';
 
 interface ChannelConfig {
   prefetch: number;
 }
 
 declare class Channels {
-  constructor(connection: amqp.Connection, config: ChannelConfig);
-  private readonly _connection: amqp.Connection;
+  constructor(connection: AmqpConnection, config: ChannelConfig);
+  private readonly _connection: AmqpConnection;
   private readonly _config: ChannelConfig;
-  private readonly _channels: Map<string, { chann: Promise<amqp.Channel>; config: ChannelConfig }>;
-  get(queue: string, config: ChannelConfig): Promise<amqp.Channel>;
-  defaultChannel(): Promise<amqp.Channel>;
+  private readonly _channels: Map<string, { chann: Promise<AmqpChannel>; config: ChannelConfig }>;
+  get(queue: string, config: ChannelConfig): Promise<AmqpChannel>;
+  defaultChannel(): Promise<AmqpChannel>;
   /**
    * Creates or returns an existing channel by it's key and config.
    * @return {Promise} A promise that resolve with an amqp.node channel object
    */
-  private _get(key: string, config?: ChannelConfig): Promise<amqp.Channel>;
-  private _initNewChannel(key: string, config: ChannelConfig): Promise<amqp.Channel>;
+  private _get(key: string, config?: ChannelConfig): Promise<AmqpChannel>;
+  private _initNewChannel(key: string, config: ChannelConfig): Promise<AmqpChannel>;
 }
 
 declare class ChannelAlreadyExistsError extends Error {

--- a/types/modules/connection.d.ts
+++ b/types/modules/connection.d.ts
@@ -1,7 +1,7 @@
-import amqp = require('amqplib');
 import channels = require('./channels');
 import { Logger } from './logger';
 import { ConnectionHooks } from './hooks/connection_hooks';
+import { AmqpChannel, AmqpConnection } from './amqp';
 
 interface ConnectionConfig {
   /**
@@ -57,16 +57,16 @@ interface ConnectionConfig {
 declare class Connection {
   constructor(config: ConnectionConfig);
 
-  private _connectionPromise: Promise<amqp.Connection>;
+  private _connectionPromise: Promise<AmqpConnection>;
   private _config: ConnectionConfig;
   public hooks: ConnectionHooks;
 
   get config(): ConnectionConfig;
   set config(value: ConnectionConfig);
 
-  getConnection(): Promise<amqp.Connection>;
-  getChannel(queue: string, config: channels.ChannelConfig): Promise<amqp.Channel>;
-  getDefaultChannel(): Promise<amqp.Channel>;
+  getConnection(): Promise<AmqpConnection>;
+  getChannel(queue: string, config: channels.ChannelConfig): Promise<AmqpChannel>;
+  getDefaultChannel(): Promise<AmqpChannel>;
   /**
    * Register an event on the default amqp.node channel
    * @param on the channel event name to be bound with
@@ -74,16 +74,16 @@ declare class Connection {
    */
   addListener(on: string, func: Function): Promise<void>;
 
-  private _connect(): Promise<amqp.Connection>;
+  private _connect(): Promise<AmqpConnection>;
 }
 
 declare function connection(config: ConnectionConfig): Connection;
 
 declare namespace connection {
   export interface Connection {
-    getConnection(): Promise<amqp.Connection>;
-    getChannel(queue: string, config: channels.ChannelConfig): Promise<amqp.Channel>;
-    getDefaultChannel(): Promise<amqp.Channel>;
+    getConnection(): Promise<AmqpConnection>;
+    getChannel(queue: string, config: channels.ChannelConfig): Promise<AmqpChannel>;
+    getDefaultChannel(): Promise<AmqpChannel>;
     /**
      * Register an event on the default amqp.node channel
      * @param on the channel event name to be bound with

--- a/types/modules/consumer.d.ts
+++ b/types/modules/consumer.d.ts
@@ -1,12 +1,12 @@
+import { AmqpOptions, AmqpMessageProperties, AmqpChannel, AmqpMessage } from './amqp';
 import { ChannelConfig } from './channels';
 import { Connection } from './connection';
 import { ConsumerHooks } from './hooks';
-import type amqp = require('amqplib');
 
-type ConsumeOptions = amqp.Options.AssertQueue & {
+type ConsumeOptions = AmqpOptions.AssertQueue & {
   channel: ChannelConfig;
 };
-type ConsumeCallback = (body: unknown, properties: amqp.MessageProperties) => Promise<unknown> | unknown;
+type ConsumeCallback = (body: unknown, properties: AmqpMessageProperties) => Promise<unknown> | unknown;
 
 declare class Consumer {
   constructor(connection: Connection);
@@ -21,10 +21,10 @@ declare class Consumer {
    * @return The message properties if it is not an rpc request, or a boolean indicating the produce result when an rpc response was produced.
    */
   private checkRpc(
-    messageProperties: amqp.MessageProperties,
+    messageProperties: AmqpMessageProperties,
     queue: string,
     reply: unknown,
-  ): Promise<boolean | amqp.MessageProperties>;
+  ): Promise<boolean | AmqpMessageProperties>;
   /**
    * Create a durable queue on RabbitMQ and consumes messages from it - executing a callback function.
    * Automatically answers with the callback response (can be a Promise)
@@ -48,12 +48,12 @@ declare class Consumer {
   /** @see Consumer.consume */
   subscribe(queue: string, callback: ConsumeCallback): Promise<true>;
 
-  private _initializeChannel(queue: string, options: ConsumeOptions, callback): Promise<amqp.Channel>;
-  private _consumeQueue(channel: amqp.Channel, queue: string, callback: ConsumeCallback): Promise<void>;
+  private _initializeChannel(queue: string, options: ConsumeOptions, callback): Promise<AmqpChannel>;
+  private _consumeQueue(channel: AmqpChannel, queue: string, callback: ConsumeCallback): Promise<void>;
   private _rejectMessageAfterProcess(
-    channel: amqp.Channel,
+    channel: AmqpChannel,
     queue: string,
-    msg: amqp.Message,
+    msg: AmqpMessage,
     parsedBody: unknown,
     requeue: boolean,
     error: Error,

--- a/types/modules/hooks/connection_hooks.d.ts
+++ b/types/modules/hooks/connection_hooks.d.ts
@@ -1,6 +1,6 @@
 import BaseHooks = require('./base_hooks');
 import { Connection, ConnectionConfig } from '../connection';
-import type amqp = require('amqplib');
+import { AmqpConnection } from '../amqp';
 
 type BeforeConnectHook = (this: Connection, event: { config: ConnectionConfig }) => Promise<void>;
 type AfterConnectHook = (this: Connection, event: AfterConnectInfo) => Promise<void>;
@@ -8,7 +8,7 @@ type AfterConnectInfo = {
   config: ConnectionConfig;
 } & (
   | {
-      connection: amqp.Connection;
+      connection: AmqpConnection;
       error: undefined;
     }
   | {

--- a/types/modules/hooks/consumer_hooks.d.ts
+++ b/types/modules/hooks/consumer_hooks.d.ts
@@ -1,6 +1,6 @@
+import { AmqpMessage, AmqpMessageProperties } from '../amqp';
 import Consumer = require('../consumer');
 import BaseHooks = require('./base_hooks');
-import type amqp = require('amqplib');
 
 type BeforeProcessHook = (this: Consumer, e: ConsumeInfo) => Promise<void>;
 
@@ -15,7 +15,7 @@ interface ConsumeInfo {
   queue: string;
   action: {
     /** The raw amqplib message */
-    message: amqp.Message;
+    message: AmqpMessage;
     /** The deserialized message content */
     content: unknown;
     /** The callback to be executed with the message */
@@ -25,9 +25,9 @@ interface ConsumeInfo {
 
 interface RpcInfo {
   /** The properties of the original message we reply to */
-  receiveProperties: amqp.MessageProperties;
+  receiveProperties: AmqpMessageProperties;
   /** The properties added to the reply message */
-  replyProperties: amqp.MessageProperties;
+  replyProperties: AmqpMessageProperties;
   /** The queue that the original message was consumed from */
   queue: string;
   /** The value to send back, before serialization. Returned from the "consume" callback. */
@@ -51,7 +51,7 @@ type RpcResultInfo = RpcInfo &
 
 type AfterConsumeInfo = {
   /** The raw amqplib message */
-  message: amqp.Message;
+  message: AmqpMessage;
   /** The deserialized message content */
   content: unknown;
 

--- a/types/modules/hooks/producer_hooks.d.ts
+++ b/types/modules/hooks/producer_hooks.d.ts
@@ -1,6 +1,6 @@
+import { AmqpMessageProperties } from '../amqp';
 import Producer = require('../producer');
 import BaseHooks = require('./base_hooks');
-import type amqp = require('amqplib');
 
 interface ProduceInfo {
   /** The queue or exchange to produce to */
@@ -32,7 +32,7 @@ type ProduceResultInfo = ProduceInfo &
 type AfterProduceHook = (this: Producer, e: ProduceResultInfo) => Promise<void>;
 type BeforeProduceHook = (this: Producer, e: ProduceInfo) => Promise<void>;
 
-type ProduceSettings = amqp.MessageProperties & {
+type ProduceSettings = AmqpMessageProperties & {
   routingKey?: string;
   rpc?: boolean;
 };

--- a/types/modules/message-parsers.d.ts
+++ b/types/modules/message-parsers.d.ts
@@ -1,5 +1,5 @@
-declare function _in(msg: amqp.Message): unknown;
-export { _in as in };
-export function out(content: unknown, options: amqp.Options.Publish): Buffer;
+import { AmqpMessage, AmqpOptions } from './amqp';
 
-import type amqp = require('amqplib');
+declare function _in(msg: AmqpMessage): unknown;
+export { _in as in };
+export function out(content: unknown, options: AmqpOptions.Publish): Buffer;

--- a/types/modules/producer.d.ts
+++ b/types/modules/producer.d.ts
@@ -1,13 +1,13 @@
+import { AmqpMessage, AmqpOptions } from './amqp';
 import { Connection } from './connection';
 import { ProducerHooks } from './hooks';
-import type amqp = require('amqplib');
 import pDefer = require('p-defer');
 
 declare class ProducerError extends Error {
   constructor(error: { name: string; message: string });
 }
 
-interface ProduceOptions extends amqp.Options.Publish {
+interface ProduceOptions extends AmqpOptions.Publish {
   routingKey?: string;
   rpc?: boolean;
 }
@@ -32,7 +32,7 @@ declare class Producer {
    * @param queue name of the queue where messages are SENT
    * @return function executed by an amqp.node channel consume callback method
    */
-  private maybeAnswer(queue: string): (msg: amqp.Message) => void;
+  private maybeAnswer(queue: string): (msg: AmqpMessage) => void;
   /**
    * Create a RPC-ready queue
    * @param  queue the queue name in which we send a RPC request


### PR DESCRIPTION
In order to not force users of the arnavmq package to also install the entire @types/amqplib for their project to compile.