### PR TITLE
Add `@types/amqplib` to prod dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arnavmq",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "ArnavMQ is a RabbitMQ wrapper",
   "keywords": [
     "rabbitmq",

--- a/package.json
+++ b/package.json
@@ -34,13 +34,13 @@
   },
   "homepage": "https://github.com/bringg/node-arnavmq#readme",
   "dependencies": {
+    "@types/amqplib": "^0.10.5",
     "amqplib": "^0.10.3",
     "p-defer": "^3.0.0",
     "serialize-error": "^8.0.1",
     "uuid": "^9.0.0"
   },
   "devDependencies": {
-    "@types/amqplib": "^0.10.5",
     "child-process-promise": "^2.2.1",
     "dot-only-hunter": "^1.0.3",
     "eslint": "^8.25.0",


### PR DESCRIPTION
So projects that rely on it don't need to install it manually to compile.