### PR TITLE
Graceful shutdown for RabbitMQ consumers (0.18.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,9 +144,13 @@ For full details of the available hooks and callback signatures, check the docum
 
 ## Graceful shutdown
 
-Call `arnavmq.close()` to shut down cleanly: it rejects pending RPC waiters, cancels consumers, drains in-flight message handlers (no timeout — waits until every one finishes), then closes the connection. It is idempotent, so repeated calls are cheap no-ops. This is the only supported shutdown API — the individual steps (consumer cancel/stop/drain, producer stop, connection close) are internal and not exposed.
+Call `arnavmq.close()` to shut down cleanly: it stops consuming, waits for every in-flight message handler to finish (no timeout — waits until every one does), then closes the connection. It is idempotent, so repeated calls are cheap no-ops. This is the only supported shutdown API — the individual steps (consumer cancel/drain, connection close) are internal and not exposed.
 
-Pending RPC waiters are rejected with `ConnectionClosedError` first, before the drain, so shutdown is never held open by a handler waiting on a response that the peer — cancelled a moment later — is never going to send. A handler that is still draining can therefore no longer make a _new_ RPC request, but it can still `publish()` normally, and can still reply to an RPC request it had already received.
+The connection stays open for the whole drain, so a handler can finish its work: `publish()` downstream, answer an RPC request it had already received, or complete a new RPC round-trip of its own. Anything a handler starts is waited on as well.
+
+There is no drain timeout, so a handler that never finishes means `close()` never resolves — deliberately left to your orchestrator's kill grace period (`terminationGracePeriodSeconds` and friends) rather than this library abandoning in-flight work on a clock. Note that this covers a handler awaiting an RPC response nobody is left to send, which is what happens when the peer is shutting down at the same time.
+
+Any RPC request still pending when the connection closes is rejected with `ConnectionClosedError` rather than hanging until `rpcTimeout` (which arms no timer at all when `rpcTimeout: 0`). That applies to a connection lost unexpectedly too, not just a deliberate `close()`.
 
 ```javascript
 await arnavmq.close();

--- a/README.md
+++ b/README.md
@@ -142,6 +142,23 @@ For full details of the available hooks and callback signatures, check the docum
 - [Consumer](src/modules/hooks/consumer_hooks.js)
 - [Producer](src/modules/hooks/producer_hooks.js)
 
+## Graceful shutdown
+
+Call `arnavmq.close()` to shut down cleanly: it cancels consumers, drains in-flight message handlers (no timeout — waits until every one finishes), rejects pending RPC waiters, then closes the connection. It is idempotent, so repeated calls are cheap no-ops.
+
+```javascript
+await arnavmq.close();
+```
+
+Lower-level primitives are also exposed on `arnavmq.consumer` for finer control:
+
+```javascript
+await arnavmq.consumer.cancel('queue:name'); // basic.cancel for a single queue, without closing the channel
+await arnavmq.consumer.drain(); // wait for in-flight handlers across all consumers to finish
+await arnavmq.consumer.stop(); // cancel + drain for every consumer
+arnavmq.consumer.inFlight(); // number of handlers currently running
+```
+
 ## Config
 
 You can specify a config object, properties and default values are:

--- a/README.md
+++ b/README.md
@@ -144,18 +144,15 @@ For full details of the available hooks and callback signatures, check the docum
 
 ## Graceful shutdown
 
-Call `arnavmq.close()` to shut down cleanly: it cancels consumers, drains in-flight message handlers (no timeout — waits until every one finishes), rejects pending RPC waiters, then closes the connection. It is idempotent, so repeated calls are cheap no-ops.
+Call `arnavmq.close()` to shut down cleanly: it cancels consumers, drains in-flight message handlers (no timeout — waits until every one finishes), rejects pending RPC waiters, then closes the connection. It is idempotent, so repeated calls are cheap no-ops. This is the only supported shutdown API — the individual steps (consumer cancel/stop/drain, producer stop, connection close) are internal and not exposed.
 
 ```javascript
 await arnavmq.close();
 ```
 
-Lower-level primitives are also exposed on `arnavmq.consumer` for finer control:
+`arnavmq.consumer.inFlight()` is also exposed, for observing in-flight work without triggering a shutdown:
 
 ```javascript
-await arnavmq.consumer.cancel('queue:name'); // basic.cancel for a single queue, without closing the channel
-await arnavmq.consumer.drain(); // wait for in-flight handlers across all consumers to finish
-await arnavmq.consumer.stop(); // cancel + drain for every consumer
 arnavmq.consumer.inFlight(); // number of handlers currently running
 ```
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,9 @@ For full details of the available hooks and callback signatures, check the docum
 
 ## Graceful shutdown
 
-Call `arnavmq.close()` to shut down cleanly: it cancels consumers, drains in-flight message handlers (no timeout — waits until every one finishes), rejects pending RPC waiters, then closes the connection. It is idempotent, so repeated calls are cheap no-ops. This is the only supported shutdown API — the individual steps (consumer cancel/stop/drain, producer stop, connection close) are internal and not exposed.
+Call `arnavmq.close()` to shut down cleanly: it rejects pending RPC waiters, cancels consumers, drains in-flight message handlers (no timeout — waits until every one finishes), then closes the connection. It is idempotent, so repeated calls are cheap no-ops. This is the only supported shutdown API — the individual steps (consumer cancel/stop/drain, producer stop, connection close) are internal and not exposed.
+
+Pending RPC waiters are rejected with `ConnectionClosedError` first, before the drain, so shutdown is never held open by a handler waiting on a response that the peer — cancelled a moment later — is never going to send. A handler that is still draining can therefore no longer make a _new_ RPC request, but it can still `publish()` normally, and can still reply to an RPC request it had already received.
 
 ```javascript
 await arnavmq.close();

--- a/README.md
+++ b/README.md
@@ -144,7 +144,9 @@ For full details of the available hooks and callback signatures, check the docum
 
 ## Graceful shutdown
 
-Call `arnavmq.close()` to shut down cleanly: it stops consuming, waits for every in-flight message handler to finish (no timeout — waits until every one does), then closes the connection. It is idempotent, so repeated calls are cheap no-ops. This is the only supported shutdown API — the individual steps (consumer cancel/drain, connection close) are internal and not exposed.
+Call `arnavmq.close()` to shut down cleanly: it stops consuming, waits for every in-flight message handler to finish (no timeout — waits until every one does), then closes the connection. It is idempotent, so repeated calls are cheap no-ops.
+
+`arnavmq.close()` is the only supported way to shut down, and it is terminal for the process: afterwards `publish()` and `subscribe()` both reject with `ConnectionClosedError`, and re-configuring the library hands back the same closed instance rather than reconnecting. `arnavmq.connection.close()` is reachable but is **not** a shutdown API - it closes the socket without stopping consumers or draining them, so a handler that is midway through its work loses the connection under it and its message is redelivered.
 
 The connection stays open for the whole drain, so a handler can finish its work: `publish()` downstream, answer an RPC request it had already received, or complete a new RPC round-trip of its own. Anything a handler starts is waited on as well.
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -37,6 +37,15 @@ export default [
       'samples/**/*',
     ],
   },
+  // `js.configs.recommended` is handed to FlatCompat above as its `recommendedConfig` option, but
+  // that only tells FlatCompat how to resolve `extends: 'eslint:recommended'` inside a *legacy*
+  // config - it does not enable a single rule here. It has to be in this array to apply. Without
+  // it `npm run lint` enforced nothing but the explicit rules below: no-unsafe-finally,
+  // no-unused-vars and the rest of the recommended set were all off, which is how a
+  // `return clearTimeout(id)` inside a `finally` (silently swallowing every rejection routed
+  // through utils.withTimeout) passed CI.
+  js.configs.recommended,
+  // After recommended, so it can switch off anything that would fight the formatter.
   ...compat.extends('eslint-config-prettier'),
   {
     languageOptions: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arnavmq",
-  "version": "0.17.2",
+  "version": "0.18.0",
   "description": "ArnavMQ is a RabbitMQ wrapper",
   "keywords": [
     "rabbitmq",

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,10 @@ module.exports = (config) => {
     // default timeout for RPC calls. If set to '0' there will be none.
     rpcTimeout: 15000,
 
+    // default drain budget (ms) for close()'s graceful shutdown: how long to wait for in-flight
+    // consumer handlers to finish before rejecting+requeueing them and closing the connection.
+    shutdownTimeout: 30000,
+
     // suffix all queues names
     // ex: service-something with suffix :ci becomes service-suffix:ci etc.
     consumerSuffix: '',
@@ -46,3 +50,9 @@ module.exports = (config) => {
 
   return require('./modules/arnavmq')(connection(configuration));
 };
+
+// `instanceof arnavmq.ConnectionClosedError` is the documented way callers detect the
+// "connection is shutting down" rejection from produce()/publish(), so the class has to exist on the
+// package's main entry point at runtime, not just in types/index.d.ts. Assigned after the
+// module.exports assignment above - assigning it before would be clobbered by it.
+module.exports.ConnectionClosedError = connection.ConnectionClosedError;

--- a/src/index.js
+++ b/src/index.js
@@ -23,10 +23,6 @@ module.exports = (config) => {
     // default timeout for RPC calls. If set to '0' there will be none.
     rpcTimeout: 15000,
 
-    // default drain budget (ms) for close()'s graceful shutdown: how long to wait for in-flight
-    // consumer handlers to finish before rejecting+requeueing them and closing the connection.
-    shutdownTimeout: 30000,
-
     // suffix all queues names
     // ex: service-something with suffix :ci becomes service-suffix:ci etc.
     consumerSuffix: '',

--- a/src/modules/arnavmq.js
+++ b/src/modules/arnavmq.js
@@ -73,9 +73,6 @@ module.exports = (connection) => {
   const consumer = {
     consume: instance.consume.bind(instance),
     subscribe: instance.subscribe.bind(instance),
-    cancel: instance.consumer.cancel.bind(instance.consumer),
-    stop: instance.consumer.stop.bind(instance.consumer),
-    drain: instance.consumer.drain.bind(instance.consumer),
     inFlight: instance.consumer.inFlight.bind(instance.consumer),
   };
 

--- a/src/modules/arnavmq.js
+++ b/src/modules/arnavmq.js
@@ -38,31 +38,25 @@ class ArnavMQ {
   }
 
   /**
-   * Graceful shutdown: cancel consumers -> drain in-flight handlers (rejecting+requeueing any
-   * still running past the timeout) -> reject pending RPC waiters -> close the connection.
-   * Idempotent - every step it delegates to (consumer.stop(), producer.stop(), connection.close())
-   * is itself idempotent, so repeated calls are cheap no-ops rather than re-running the sequence.
+   * Graceful shutdown: cancel consumers -> drain in-flight handlers (no timeout - waits until
+   * every one finishes) -> reject pending RPC waiters -> close the connection. Idempotent - every
+   * step it delegates to (consumer.stop(), producer.stop(), connection.close()) is itself
+   * idempotent, so repeated calls are cheap no-ops rather than re-running the sequence.
    *
    * The connection is deliberately kept open through the cancel/drain step: `checkRpc` needs it to
    * reply, and handlers may still `produce()`/`publish()` as part of their work while draining.
    * `connection.close()` (the last step) is the first point at which produce()/publish() starts
    * failing with `ConnectionClosedError`.
-   * @param {object} [options]
-   * @param {number} [options.timeout] Drain budget in ms, passed through to consumer.stop().
-   *   Defaults to the `shutdownTimeout` config value (30000ms).
-   * @return {Promise<{drained: boolean, abandoned: Record<string, number>}>} The drain outcome:
-   *   `drained` is false when the timeout elapsed and messages had to be abandoned, and `abandoned`
-   *   maps queue name to how many messages were abandoned on it (`{}` on a clean drain). Surfaced so
-   *   callers can log/emit a shutdown metric; ignoring the return value is perfectly fine.
+   *
+   * There is no drain timeout: a handler that never finishes means close() never resolves. That is
+   * left to the process orchestrator's own kill grace period rather than this library abandoning
+   * in-flight work on a clock.
+   * @return {Promise<void>}
    */
-  async close(options = {}) {
-    const timeout = options.timeout ?? this.connection.config?.shutdownTimeout;
-
-    const { drained, abandoned } = await this.consumer.stop({ timeout });
+  async close() {
+    await this.consumer.stop();
     this.producer.stop();
     await this.connection.close();
-
-    return { drained, abandoned };
   }
 }
 

--- a/src/modules/arnavmq.js
+++ b/src/modules/arnavmq.js
@@ -36,10 +36,37 @@ class ArnavMQ {
   publish(queue, msg, options) {
     return this.producer.publish(queue, msg, options);
   }
+
+  /**
+   * Graceful shutdown: cancel consumers -> drain in-flight handlers (rejecting+requeueing any
+   * still running past the timeout) -> reject pending RPC waiters -> close the connection.
+   * Idempotent - every step it delegates to (consumer.stop(), producer.stop(), connection.close())
+   * is itself idempotent, so repeated calls are cheap no-ops rather than re-running the sequence.
+   *
+   * The connection is deliberately kept open through the cancel/drain step: `checkRpc` needs it to
+   * reply, and handlers may still `produce()`/`publish()` as part of their work while draining.
+   * `connection.close()` (the last step) is the first point at which produce()/publish() starts
+   * failing with `ConnectionClosedError`.
+   * @param {object} [options]
+   * @param {number} [options.timeout] Drain budget in ms, passed through to consumer.stop().
+   *   Defaults to the `shutdownTimeout` config value (30000ms).
+   * @return {Promise<{drained: boolean, abandoned: Record<string, number>}>} The drain outcome:
+   *   `drained` is false when the timeout elapsed and messages had to be abandoned, and `abandoned`
+   *   maps queue name to how many messages were abandoned on it (`{}` on a clean drain). Surfaced so
+   *   callers can log/emit a shutdown metric; ignoring the return value is perfectly fine.
+   */
+  async close(options = {}) {
+    const timeout = options.timeout ?? this.connection.config?.shutdownTimeout;
+
+    const { drained, abandoned } = await this.consumer.stop({ timeout });
+    this.producer.stop();
+    await this.connection.close();
+
+    return { drained, abandoned };
+  }
 }
 
 let instance;
-module.exports.ArnavMQ = ArnavMQ;
 module.exports = (connection) => {
   assert(instance || connection, 'ArnavMQ can not be initialized because connection does not exist');
 
@@ -52,6 +79,10 @@ module.exports = (connection) => {
   const consumer = {
     consume: instance.consume.bind(instance),
     subscribe: instance.subscribe.bind(instance),
+    cancel: instance.consumer.cancel.bind(instance.consumer),
+    stop: instance.consumer.stop.bind(instance.consumer),
+    drain: instance.consumer.drain.bind(instance.consumer),
+    inFlight: instance.consumer.inFlight.bind(instance.consumer),
   };
 
   const producer = {
@@ -71,8 +102,15 @@ module.exports = (connection) => {
     subscribe: consumer.subscribe,
     produce: producer.produce,
     publish: producer.publish,
+    close: instance.close.bind(instance),
     consumer,
     producer,
     hooks,
   };
 };
+
+// Exposed for tests that need an ArnavMQ instance isolated from the process-wide singleton above
+// (e.g. to exercise close() without terminally closing the connection every other spec file
+// shares). Assigned after the module.exports reassignment above - assigning it before, the way
+// this file previously did, gets clobbered by that reassignment and is unreachable.
+module.exports.ArnavMQ = ArnavMQ;

--- a/src/modules/arnavmq.js
+++ b/src/modules/arnavmq.js
@@ -38,34 +38,26 @@ class ArnavMQ {
   }
 
   /**
-   * Graceful shutdown: reject pending RPC waiters -> cancel consumers -> drain in-flight handlers
-   * (no timeout - waits until every one finishes) -> close the connection. Idempotent - every step
-   * it delegates to (producer.stop(), consumer.stop(), connection.close()) is itself idempotent,
-   * so repeated calls are cheap no-ops rather than re-running the sequence.
+   * Graceful shutdown: stop consuming -> let every in-flight handler finish (no timeout) -> close
+   * the connection. Idempotent; repeated calls are cheap no-ops rather than re-running the
+   * sequence.
    *
-   * `producer.stop()` runs first, and is synchronous, so a handler parked on an RPC response can
-   * never hold the drain open. Whoever would have answered that request is being cancelled by the
-   * very next step, so the response is never coming - and draining first deadlocks: `drain()`
-   * waits on a handler that only `producer.stop()` can release, while `producer.stop()` waits on
-   * `drain()`. That stalls shutdown for `rpcTimeout` per parked handler, or forever with
-   * `rpcTimeout: 0` (no timeout timer is ever armed in that case).
+   * The connection stays open for the whole drain, so a handler can finish its work: publish
+   * downstream, reply to an RPC request it had already received, or await an RPC response of its
+   * own - the reply-queue consumer is not one of the subscriptions that get cancelled, so answers
+   * keep arriving. Anything a handler starts is waited on too.
    *
-   * The connection is still deliberately kept open through the cancel/drain step. Only new
-   * outgoing RPC *requests* fail fast (with `ConnectionClosedError`) once the producer is stopped:
-   * non-RPC `produce()`/`publish()` keeps working, and consumer.js's `checkRpc` writes RPC
-   * *replies* straight to the channel rather than through the producer, so a draining handler can
-   * still answer a request it had already received. `connection.close()` (the last step) is the
-   * first point at which non-RPC produce()/publish() starts failing too.
+   * There is no drain timeout: a handler that never finishes means close() never resolves - left to
+   * the process orchestrator's own kill grace period rather than this library abandoning in-flight
+   * work on a clock. That includes a handler awaiting an RPC response that nobody is left to send
+   * (the peer is shutting down too, or is served by a consumer this process just cancelled).
    *
-   * There is no drain timeout: a handler that never finishes means close() never resolves. That is
-   * left to the process orchestrator's own kill grace period rather than this library abandoning
-   * in-flight work on a clock.
+   * Closing the connection is what fails pending RPC waiters, via producer.js's channel-close
+   * listener - so callers fail fast with `ConnectionClosedError` rather than hanging out
+   * `rpcTimeout`.
    * @return {Promise<void>}
    */
   async close() {
-    // Synchronous, and ahead of consumer.stop(), so every pending RPC waiter is rejected in the
-    // same turn of the loop that flips the consumer's shutting-down latch.
-    this.producer.stop();
     await this.consumer.stop();
     await this.connection.close();
   }

--- a/src/modules/arnavmq.js
+++ b/src/modules/arnavmq.js
@@ -38,15 +38,24 @@ class ArnavMQ {
   }
 
   /**
-   * Graceful shutdown: cancel consumers -> drain in-flight handlers (no timeout - waits until
-   * every one finishes) -> reject pending RPC waiters -> close the connection. Idempotent - every
-   * step it delegates to (consumer.stop(), producer.stop(), connection.close()) is itself
-   * idempotent, so repeated calls are cheap no-ops rather than re-running the sequence.
+   * Graceful shutdown: reject pending RPC waiters -> cancel consumers -> drain in-flight handlers
+   * (no timeout - waits until every one finishes) -> close the connection. Idempotent - every step
+   * it delegates to (producer.stop(), consumer.stop(), connection.close()) is itself idempotent,
+   * so repeated calls are cheap no-ops rather than re-running the sequence.
    *
-   * The connection is deliberately kept open through the cancel/drain step: `checkRpc` needs it to
-   * reply, and handlers may still `produce()`/`publish()` as part of their work while draining.
-   * `connection.close()` (the last step) is the first point at which produce()/publish() starts
-   * failing with `ConnectionClosedError`.
+   * `producer.stop()` runs first, and is synchronous, so a handler parked on an RPC response can
+   * never hold the drain open. Whoever would have answered that request is being cancelled by the
+   * very next step, so the response is never coming - and draining first deadlocks: `drain()`
+   * waits on a handler that only `producer.stop()` can release, while `producer.stop()` waits on
+   * `drain()`. That stalls shutdown for `rpcTimeout` per parked handler, or forever with
+   * `rpcTimeout: 0` (no timeout timer is ever armed in that case).
+   *
+   * The connection is still deliberately kept open through the cancel/drain step. Only new
+   * outgoing RPC *requests* fail fast (with `ConnectionClosedError`) once the producer is stopped:
+   * non-RPC `produce()`/`publish()` keeps working, and consumer.js's `checkRpc` writes RPC
+   * *replies* straight to the channel rather than through the producer, so a draining handler can
+   * still answer a request it had already received. `connection.close()` (the last step) is the
+   * first point at which non-RPC produce()/publish() starts failing too.
    *
    * There is no drain timeout: a handler that never finishes means close() never resolves. That is
    * left to the process orchestrator's own kill grace period rather than this library abandoning
@@ -54,8 +63,10 @@ class ArnavMQ {
    * @return {Promise<void>}
    */
   async close() {
-    await this.consumer.stop();
+    // Synchronous, and ahead of consumer.stop(), so every pending RPC waiter is rejected in the
+    // same turn of the loop that flips the consumer's shutting-down latch.
     this.producer.stop();
+    await this.consumer.stop();
     await this.connection.close();
   }
 }

--- a/src/modules/channels.js
+++ b/src/modules/channels.js
@@ -104,8 +104,17 @@ class Channels {
    * - so a handler's `ack()` returning only means the frame was written to the socket, not that the
    * broker processed it. `Channel.Close` *does* round-trip (amqplib resolves `close()` on
    * `Channel.Close-Ok`), and a broker processes one channel's frames in order, so once this
-   * resolves every frame previously written on those channels - the acks included - is guaranteed
-   * to have been processed.
+   * resolves every frame already *written* to the socket - the acks included - is guaranteed to have
+   * been processed.
+   *
+   * Written, not merely requested: acks and rejects go out through amqplib's `sendImmediately`, so
+   * they are genuinely ordered ahead of the `Channel.Close`. A synchronous method does not
+   * necessarily - `sendOrEnqueue` parks it in the channel's `pending` list whenever another RPC is
+   * still awaiting its reply, `Channel.Close` then jumps that list (it is `sendImmediately` too),
+   * and `toClosed()` -> `_rejectPending()` discards whatever was parked with "Channel ended, no
+   * reply will be forthcoming". So a `basic.cancel` that had been queued behind another RPC can be
+   * dropped here - which is where `_cancelSubscription`'s "Failed to cancel consumer" log comes
+   * from in that case: local frame dropping, not a broker refusal.
    *
    * Terminal: only call this when nothing in the process will ask for a channel again (see
    * `Connection.close()`, which is terminal for the process, and is the only caller).

--- a/src/modules/channels.js
+++ b/src/modules/channels.js
@@ -1,5 +1,5 @@
-const pDefer = require('p-defer');
 const { logger } = require('./logger');
+const { withTimeout } = require('./utils');
 
 const DEFAULT_CHANNEL = 'DEFAULT_CHANNEL';
 
@@ -7,27 +7,6 @@ const DEFAULT_CHANNEL = 'DEFAULT_CHANNEL';
 // best-effort: the caller tears the connection down either way, so a broker that stops answering
 // must not be able to hang the process's shutdown.
 const CLOSE_CHANNEL_TIMEOUT_MS = 5000;
-
-/**
- * Resolves with `promise`, or rejects once `timeoutMs` elapses - whichever happens first.
- * A rejection handler is attached to `promise` up front so that if it loses the race and rejects
- * later, that rejection is already handled instead of surfacing as an unhandled rejection.
- * @param {Promise} promise
- * @param {number} timeoutMs
- * @param {string} what Described in the timeout error message.
- * @return {Promise}
- */
-function withTimeout(promise, timeoutMs, what) {
-  const deferredTimeout = pDefer();
-  const timeoutId = setTimeout(
-    () => deferredTimeout.reject(new Error(`Timed out after ${timeoutMs}ms waiting for ${what}`)),
-    timeoutMs,
-  );
-
-  promise.catch(() => {});
-
-  return Promise.race([promise, deferredTimeout.promise]).finally(() => clearTimeout(timeoutId));
-}
 
 /**
  * Gracefully close one cached channel, bounded by `CLOSE_CHANNEL_TIMEOUT_MS`. Never rejects - see
@@ -38,12 +17,6 @@ function withTimeout(promise, timeoutMs, what) {
  */
 async function closeChannel(key, entry) {
   try {
-    // The cap covers `entry.chann` too, not just `close()`. A cache entry can still be pending when
-    // shutdown starts - a channel allocated moments earlier whose `Channel.Open-Ok` or `Basic.Qos-Ok`
-    // never arrived from a broker that has stopped answering but whose TCP connection is still up -
-    // and awaiting that unbounded would hang `connection.close()` just as an unbounded `close()`
-    // would, leaving only amqplib's 60s heartbeat monitor to break the deadlock (longer than a
-    // typical 30s terminationGracePeriod, so: SIGKILL, the exact outcome this cap exists to avoid).
     await withTimeout(
       (async () => {
         const channel = await entry.chann;
@@ -53,10 +26,6 @@ async function closeChannel(key, entry) {
       `channel "${key}" to close`,
     );
   } catch (error) {
-    // Expected and harmless when the channel never opened, or the broker/an earlier error already
-    // closed it - there is nothing left to flush on it either way. Only worth noting because a
-    // channel we failed to flush is one whose last acks may still lose the race against the
-    // broker's requeue-on-disconnect cleanup.
     logger.warn({
       message: `Failed to gracefully close channel [${key}] before closing the connection - [${error.message}]`,
       error,
@@ -143,9 +112,6 @@ class Channels {
    * @return {Promise<void>}
    */
   async closeAll() {
-    // Snapshot and empty the cache up front: each channel's own 'close' listener below deletes its
-    // own entry while we await, and nothing should be handed a channel we are midway through
-    // closing.
     const entries = [...this._channels.entries()];
     this._channels.clear();
 
@@ -157,12 +123,6 @@ class Channels {
     try {
       channel = await this._connection.createChannel();
 
-      // Both listeners go on before the first await below, and must stay that way. amqplib routes a
-      // server-sent `Channel.Close` through `safeEmit(channel, 'error', ...)`, which *rethrows* when
-      // nothing is listening for 'error' (or 'handler-error') - and that throw unwinds out of
-      // amqplib's frame-processing callback into an uncaught exception that kills the process. Any
-      // await between `createChannel()` resolving and this point is a window where a broker-side
-      // channel close crashes us.
       channel.on('close', () => {
         this._channels.delete(key);
       });
@@ -173,13 +133,6 @@ class Channels {
         });
       });
 
-      // Awaited, not fire-and-forget: `prefetch()` is a `basic.qos` RPC, and closing a channel with
-      // an RPC still outstanding rejects that RPC ("Channel ended, no reply will be forthcoming").
-      // Unawaited that lands as an unhandled rejection - which `Channels.closeAll()` on shutdown
-      // makes reachable for a channel created moments before close(). Awaiting also means a failed
-      // qos surfaces through the catch below instead of silently leaving the channel misconfigured.
-      // The 'close' listener above may fire during this await and delete this key; the catch below
-      // deletes it too, which is idempotent.
       await channel.prefetch(config.prefetch);
 
       return channel;

--- a/src/modules/channels.js
+++ b/src/modules/channels.js
@@ -1,6 +1,68 @@
+const pDefer = require('p-defer');
 const { logger } = require('./logger');
 
 const DEFAULT_CHANNEL = 'DEFAULT_CHANNEL';
+
+// Cap on how long `closeAll()` waits for one channel's `Channel.Close-Ok`. The barrier is
+// best-effort: the caller tears the connection down either way, so a broker that stops answering
+// must not be able to hang the process's shutdown.
+const CLOSE_CHANNEL_TIMEOUT_MS = 5000;
+
+/**
+ * Resolves with `promise`, or rejects once `timeoutMs` elapses - whichever happens first.
+ * A rejection handler is attached to `promise` up front so that if it loses the race and rejects
+ * later, that rejection is already handled instead of surfacing as an unhandled rejection.
+ * @param {Promise} promise
+ * @param {number} timeoutMs
+ * @param {string} what Described in the timeout error message.
+ * @return {Promise}
+ */
+function withTimeout(promise, timeoutMs, what) {
+  const deferredTimeout = pDefer();
+  const timeoutId = setTimeout(
+    () => deferredTimeout.reject(new Error(`Timed out after ${timeoutMs}ms waiting for ${what}`)),
+    timeoutMs,
+  );
+
+  promise.catch(() => {});
+
+  return Promise.race([promise, deferredTimeout.promise]).finally(() => clearTimeout(timeoutId));
+}
+
+/**
+ * Gracefully close one cached channel, bounded by `CLOSE_CHANNEL_TIMEOUT_MS`. Never rejects - see
+ * `Channels.closeAll()`, its only caller.
+ * @param {string} key The channel cache key, for logging.
+ * @param {{chann: Promise}} entry The channel cache entry.
+ * @return {Promise<void>}
+ */
+async function closeChannel(key, entry) {
+  try {
+    // The cap covers `entry.chann` too, not just `close()`. A cache entry can still be pending when
+    // shutdown starts - a channel allocated moments earlier whose `Channel.Open-Ok` or `Basic.Qos-Ok`
+    // never arrived from a broker that has stopped answering but whose TCP connection is still up -
+    // and awaiting that unbounded would hang `connection.close()` just as an unbounded `close()`
+    // would, leaving only amqplib's 60s heartbeat monitor to break the deadlock (longer than a
+    // typical 30s terminationGracePeriod, so: SIGKILL, the exact outcome this cap exists to avoid).
+    await withTimeout(
+      (async () => {
+        const channel = await entry.chann;
+        await channel.close();
+      })(),
+      CLOSE_CHANNEL_TIMEOUT_MS,
+      `channel "${key}" to close`,
+    );
+  } catch (error) {
+    // Expected and harmless when the channel never opened, or the broker/an earlier error already
+    // closed it - there is nothing left to flush on it either way. Only worth noting because a
+    // channel we failed to flush is one whose last acks may still lose the race against the
+    // broker's requeue-on-disconnect cleanup.
+    logger.warn({
+      message: `Failed to gracefully close channel [${key}] before closing the connection - [${error.message}]`,
+      error,
+    });
+  }
+}
 
 class ChannelAlreadyExistsError extends Error {
   constructor(name, config) {
@@ -29,7 +91,6 @@ class Channels {
   }
 
   async get(queue, config) {
-    // If we don't have custom prefetch create a new channel
     const defaultPrefetch = this._config.prefetch;
     const requestedPrefetch = config.prefetch || defaultPrefetch;
     if (typeof requestedPrefetch === 'number' && requestedPrefetch !== defaultPrefetch) {
@@ -55,7 +116,6 @@ class Channels {
         throw new ChannelAlreadyExistsError(key, config);
       }
 
-      // cache handling, if channel already opened, return it
       return await existingChannel.chann;
     }
 
@@ -65,14 +125,44 @@ class Channels {
     return await channelPromise;
   }
 
+  /**
+   * Gracefully close every cached channel, waiting for the broker to confirm each close, and empty
+   * the cache. Never rejects: each channel is closed independently and its failure only logged, so
+   * one bad channel can neither stop the others from closing nor stop the caller from proceeding.
+   *
+   * This exists as a synchronization barrier for connection teardown, not as cleanup.
+   * `channel.ack()`/`channel.reject()` are fire-and-forget in AMQP 0-9-1 - there is no ack-ok frame
+   * - so a handler's `ack()` returning only means the frame was written to the socket, not that the
+   * broker processed it. `Channel.Close` *does* round-trip (amqplib resolves `close()` on
+   * `Channel.Close-Ok`), and a broker processes one channel's frames in order, so once this
+   * resolves every frame previously written on those channels - the acks included - is guaranteed
+   * to have been processed.
+   *
+   * Terminal: only call this when nothing in the process will ask for a channel again (see
+   * `Connection.close()`, which is terminal for the process, and is the only caller).
+   * @return {Promise<void>}
+   */
+  async closeAll() {
+    // Snapshot and empty the cache up front: each channel's own 'close' listener below deletes its
+    // own entry while we await, and nothing should be handed a channel we are midway through
+    // closing.
+    const entries = [...this._channels.entries()];
+    this._channels.clear();
+
+    await Promise.all(entries.map(([key, entry]) => closeChannel(key, entry)));
+  }
+
   async _initNewChannel(key, config) {
     let channel;
     try {
       channel = await this._connection.createChannel();
 
-      channel.prefetch(config.prefetch);
-
-      // on error we remove the channel so the next call will recreate it (auto-reconnect are handled by connection users)
+      // Both listeners go on before the first await below, and must stay that way. amqplib routes a
+      // server-sent `Channel.Close` through `safeEmit(channel, 'error', ...)`, which *rethrows* when
+      // nothing is listening for 'error' (or 'handler-error') - and that throw unwinds out of
+      // amqplib's frame-processing callback into an uncaught exception that kills the process. Any
+      // await between `createChannel()` resolving and this point is a window where a broker-side
+      // channel close crashes us.
       channel.on('close', () => {
         this._channels.delete(key);
       });
@@ -83,6 +173,15 @@ class Channels {
         });
       });
 
+      // Awaited, not fire-and-forget: `prefetch()` is a `basic.qos` RPC, and closing a channel with
+      // an RPC still outstanding rejects that RPC ("Channel ended, no reply will be forthcoming").
+      // Unawaited that lands as an unhandled rejection - which `Channels.closeAll()` on shutdown
+      // makes reachable for a channel created moments before close(). Awaiting also means a failed
+      // qos surfaces through the catch below instead of silently leaving the channel misconfigured.
+      // The 'close' listener above may fire during this await and delete this key; the catch below
+      // deletes it too, which is idempotent.
+      await channel.prefetch(config.prefetch);
+
       return channel;
     } catch (error) {
       this._channels.delete(key);
@@ -91,7 +190,6 @@ class Channels {
         error,
       });
 
-      // Should not happen, but just in case
       if (channel) {
         try {
           await channel.close();

--- a/src/modules/channels.js
+++ b/src/modules/channels.js
@@ -9,10 +9,21 @@ const DEFAULT_CHANNEL = 'DEFAULT_CHANNEL';
 const CLOSE_CHANNEL_TIMEOUT_MS = 5000;
 
 /**
+ * @typedef {Object} ChannelConfig
+ * @property {number} prefetch
+ */
+
+/**
+ * @typedef {Object} ChannelCacheEntry
+ * @property {Promise<import('amqplib').Channel>} chann
+ * @property {ChannelConfig} config
+ */
+
+/**
  * Gracefully close one cached channel, bounded by `CLOSE_CHANNEL_TIMEOUT_MS`. Never rejects - see
  * `Channels.closeAll()`, its only caller.
  * @param {string} key The channel cache key, for logging.
- * @param {{chann: Promise}} entry The channel cache entry.
+ * @param {ChannelCacheEntry} entry The channel cache entry.
  * @return {Promise<void>}
  */
 async function closeChannel(key, entry) {
@@ -34,6 +45,10 @@ async function closeChannel(key, entry) {
 }
 
 class ChannelAlreadyExistsError extends Error {
+  /**
+   * @param {string} name
+   * @param {ChannelConfig} config
+   */
   constructor(name, config) {
     const message = `Channel "${name}" already exists with config ${JSON.stringify(config)}`;
 
@@ -47,18 +62,35 @@ class ChannelAlreadyExistsError extends Error {
   }
 }
 
+/**
+ * @param {ChannelConfig} a
+ * @param {ChannelConfig} b
+ * @return {boolean}
+ */
 function isSameConfig(a, b) {
   return a.prefetch === b.prefetch;
 }
 
 class Channels {
+  /**
+   * @param {import('amqplib').ChannelModel} connection
+   * @param {ChannelConfig} config
+   */
   constructor(connection, config) {
+    /** @type {import('amqplib').ChannelModel} */
     this._connection = connection;
+    /** @type {ChannelConfig} */
     this._config = config;
 
+    /** @type {Map<string, ChannelCacheEntry>} */
     this._channels = new Map();
   }
 
+  /**
+   * @param {string} queue
+   * @param {ChannelConfig} config
+   * @return {Promise<import('amqplib').Channel>}
+   */
   async get(queue, config) {
     const defaultPrefetch = this._config.prefetch;
     const requestedPrefetch = config.prefetch || defaultPrefetch;
@@ -69,13 +101,16 @@ class Channels {
     return await this.defaultChannel();
   }
 
+  /** @return {Promise<import('amqplib').Channel>} */
   async defaultChannel() {
     return await this._get(DEFAULT_CHANNEL, { prefetch: this._config.prefetch });
   }
 
   /**
    * Creates or returns an existing channel by it's key and config.
-   * @return {Promise} A promise that resolve with an amqp.node channel object
+   * @param {string} key
+   * @param {ChannelConfig} [config]
+   * @return {Promise<import('amqplib').Channel>} A promise that resolve with an amqp.node channel object
    */
   async _get(key, config = {}) {
     const existingChannel = this._channels.get(key);
@@ -127,6 +162,11 @@ class Channels {
     await Promise.all(entries.map(([key, entry]) => closeChannel(key, entry)));
   }
 
+  /**
+   * @param {string} key
+   * @param {ChannelConfig} config
+   * @return {Promise<import('amqplib').Channel>}
+   */
   async _initNewChannel(key, config) {
     let channel;
     try {

--- a/src/modules/connection.js
+++ b/src/modules/connection.js
@@ -98,17 +98,7 @@ class Connection {
     }
 
     if (connection) {
-      const channels = this._channels;
-      if (channels) {
-        try {
-          await channels.closeAll();
-        } catch (error) {
-          logger.error({
-            message: `Error closing amqp channels: ${error.message}`,
-            error,
-          });
-        }
-      }
+      await this._channels?.closeAll();
 
       try {
         await connection.close();

--- a/src/modules/connection.js
+++ b/src/modules/connection.js
@@ -89,12 +89,12 @@ class Connection {
     try {
       connection = await this._connectionPromise;
     } catch (error) {
-      // The in-flight connect failed on its own; there's nothing for us to close.
+      // The in-flight connect failed on its own; there's nothing for us to close - `connection`
+      // keeps its initial null, since the assignment above never completed.
       logger.debug({
         message: `Ignoring failed in-flight connection attempt while closing: ${error.message}`,
         error,
       });
-      connection = null;
     }
 
     if (connection) {

--- a/src/modules/connection.js
+++ b/src/modules/connection.js
@@ -157,11 +157,22 @@ class Connection {
 
   async getChannel(queue, config) {
     await this.getConnection();
+    // `close()` flips `isClosed` synchronously (before any of its own awaits), so re-checking here,
+    // synchronously after `getConnection()` resolves and before touching `_channels`, closes the gap
+    // where `close()` ran entirely between the two awaits above and already snapshotted/cleared
+    // `_channels` in `closeAll()` - without this, we'd insert a new channel into that cleared map
+    // that `closeAll()` will never see or close before the connection socket is torn down.
+    if (this.isClosed) {
+      throw new ConnectionClosedError();
+    }
     return await this._channels.get(queue, config);
   }
 
   async getDefaultChannel() {
     await this.getConnection();
+    if (this.isClosed) {
+      throw new ConnectionClosedError();
+    }
     return await this._channels.defaultChannel();
   }
 

--- a/src/modules/connection.js
+++ b/src/modules/connection.js
@@ -16,14 +16,39 @@ function onConnectionError(error) {
   });
 }
 
+/**
+ * Thrown by `getConnection()` once `close()` has been called - the connection is terminally shut
+ * down for the process and will never reconnect.
+ */
+class ConnectionClosedError extends Error {
+  constructor(message = 'Connection is closed') {
+    super(message);
+
+    this.name = 'ConnectionClosedError';
+    this.message = message;
+
+    Error.captureStackTrace(this, this.constructor);
+  }
+}
+
 class Connection {
   constructor(config) {
     this._config = config;
 
     this._connectionPromise = null; // Promise of amqp connection
     this._channels = null;
+    this._closePromise = null;
     this.hooks = new ConnectionHooks();
     this.startedAt = new Date().toISOString();
+  }
+
+  /**
+   * Whether `close()` has been called on this connection. Once true, it never goes back to false -
+   * the connection is terminally shut down for the process.
+   * @return {boolean}
+   */
+  get isClosed() {
+    return !!this._closePromise;
   }
 
   /**
@@ -31,12 +56,94 @@ class Connection {
    * @return {Promise} A promise that resolve with an amqp.node connection object
    */
   async getConnection() {
+    if (this.isClosed) {
+      throw new ConnectionClosedError();
+    }
+
     // cache handling, if connection already opened, return it
     if (!this._connectionPromise) {
       this._connectionPromise = this._connect();
     }
 
     return await this._connectionPromise;
+  }
+
+  /**
+   * Terminally close this connection for the process: gracefully close every channel (which flushes
+   * any ack/reject still in flight to the broker - see `Channels.closeAll()`), then close the
+   * socket. Idempotent - safe to call more than once, sequentially or concurrently; every caller
+   * shares the same underlying close. Never rejects; teardown errors are logged. After this
+   * resolves, `getConnection()` (and anything built on it) rejects with `ConnectionClosedError`.
+   * @return {Promise<void>}
+   */
+  async close() {
+    if (!this._closePromise) {
+      this._closePromise = this._close();
+    }
+
+    return await this._closePromise;
+  }
+
+  async _close() {
+    // `close()` already set `this._closePromise` (which `isClosed` reads) before calling us, so any
+    // connect racing us (or starting after us) is rejected instead of handed a connection we're
+    // about to tear down.
+
+    // Don't race a connect already in progress - wait for it to settle (either way) before we
+    // try to close anything.
+    let connection = null;
+    try {
+      connection = await this._connectionPromise;
+    } catch (error) {
+      // The in-flight connect failed on its own; there's nothing for us to close.
+      logger.debug({
+        message: `Ignoring failed in-flight connection attempt while closing: ${error.message}`,
+        error,
+      });
+      connection = null;
+    }
+
+    if (connection) {
+      // Flush the channels before tearing the socket down, don't just drop them with it. A drained
+      // handler's `channel.ack()` is fire-and-forget on the wire (AMQP 0-9-1 has no ack-ok frame),
+      // so closing the raw connection immediately after it races that ack against the broker's own
+      // "requeue everything still unacked on this connection" cleanup - and loses often enough to
+      // redeliver a message that was fully processed and acked. `Channels.closeAll()` round-trips
+      // with the broker per channel, which guarantees those acks were processed first.
+      //
+      // Read `this._channels` only after the await above: the connection's own 'close' handler
+      // nulls it, and the connection may have died while we were waiting for the connect to settle.
+      //
+      // Closing a channel emits 'close' on it, which consumer.js listens for to resubscribe.
+      // Consumer._isLive() checks `this._connection.isClosed` (set above, before this await), so
+      // that listener is a no-op regardless of whether `arnavmq.close()` ran `consumer.stop()`
+      // first - calling this method directly is safe even with active subscriptions.
+      const channels = this._channels;
+      if (channels) {
+        try {
+          await channels.closeAll();
+        } catch (error) {
+          // closeAll() already logs and swallows per channel; this is belt-and-braces so a broken
+          // channel cache can never stop us from closing the socket, or make close() reject.
+          logger.error({
+            message: `Error closing amqp channels: ${error.message}`,
+            error,
+          });
+        }
+      }
+
+      try {
+        await connection.close();
+      } catch (error) {
+        logger.error({
+          message: `Error closing amqp connection: ${error.message}`,
+          error,
+        });
+      }
+    }
+
+    this._connectionPromise = null;
+    this._channels = null;
   }
 
   async _connect() {
@@ -111,3 +218,9 @@ module.exports = (config) => {
   }
   return instance;
 };
+
+// Exposed for `instanceof` checks by consumers of the singleton (e.g. producer.js's
+// reconnect-on-close listener) and for tests that need a Connection instance isolated from the
+// process-wide singleton above.
+module.exports.ConnectionClosedError = ConnectionClosedError;
+module.exports.Connection = Connection;

--- a/src/modules/connection.js
+++ b/src/modules/connection.js
@@ -85,12 +85,6 @@ class Connection {
   }
 
   async _close() {
-    // `close()` already set `this._closePromise` (which `isClosed` reads) before calling us, so any
-    // connect racing us (or starting after us) is rejected instead of handed a connection we're
-    // about to tear down.
-
-    // Don't race a connect already in progress - wait for it to settle (either way) before we
-    // try to close anything.
     let connection = null;
     try {
       connection = await this._connectionPromise;
@@ -104,27 +98,11 @@ class Connection {
     }
 
     if (connection) {
-      // Flush the channels before tearing the socket down, don't just drop them with it. A drained
-      // handler's `channel.ack()` is fire-and-forget on the wire (AMQP 0-9-1 has no ack-ok frame),
-      // so closing the raw connection immediately after it races that ack against the broker's own
-      // "requeue everything still unacked on this connection" cleanup - and loses often enough to
-      // redeliver a message that was fully processed and acked. `Channels.closeAll()` round-trips
-      // with the broker per channel, which guarantees those acks were processed first.
-      //
-      // Read `this._channels` only after the await above: the connection's own 'close' handler
-      // nulls it, and the connection may have died while we were waiting for the connect to settle.
-      //
-      // Closing a channel emits 'close' on it, which consumer.js listens for to resubscribe.
-      // Consumer._isLive() checks `this._connection.isClosed` (set above, before this await), so
-      // that listener is a no-op regardless of whether `arnavmq.close()` ran `consumer.stop()`
-      // first - calling this method directly is safe even with active subscriptions.
       const channels = this._channels;
       if (channels) {
         try {
           await channels.closeAll();
         } catch (error) {
-          // closeAll() already logs and swallows per channel; this is belt-and-braces so a broken
-          // channel cache can never stop us from closing the socket, or make close() reject.
           logger.error({
             message: `Error closing amqp channels: ${error.message}`,
             error,

--- a/src/modules/connection.js
+++ b/src/modules/connection.js
@@ -85,16 +85,18 @@ class Connection {
   }
 
   async _close() {
-    let connection = null;
+    let connection;
     try {
       connection = await this._connectionPromise;
     } catch (error) {
       // The in-flight connect failed on its own; there's nothing for us to close - `connection`
-      // keeps its initial null, since the assignment above never completed.
+      // stays unset, since the assignment above never completed.
       logger.debug({
         message: `Ignoring failed in-flight connection attempt while closing: ${error.message}`,
         error,
       });
+
+      return;
     }
 
     if (connection) {

--- a/src/modules/connection.js
+++ b/src/modules/connection.js
@@ -32,6 +32,7 @@ class ConnectionClosedError extends Error {
 
     this.name = 'ConnectionClosedError';
     this.message = message;
+    /** @type {'shutdown'|'unexpected'} */
     this.origin = origin;
 
     Error.captureStackTrace(this, this.constructor);
@@ -39,13 +40,22 @@ class ConnectionClosedError extends Error {
 }
 
 class Connection {
+  /**
+   * @param {import('../../types/modules/connection').ConnectionConfig} config
+   */
   constructor(config) {
+    /** @type {import('../../types/modules/connection').ConnectionConfig} */
     this._config = config;
 
-    this._connectionPromise = null; // Promise of amqp connection
+    /** @type {Promise<import('amqplib').ChannelModel>|null} */
+    this._connectionPromise = null;
+    /** @type {import('./channels').Channels|null} */
     this._channels = null;
+    /** @type {Promise<void>|null} */
     this._closePromise = null;
+    /** @type {ConnectionHooks} */
     this.hooks = new ConnectionHooks();
+    /** @type {string} */
     this.startedAt = new Date().toISOString();
   }
 
@@ -60,7 +70,7 @@ class Connection {
 
   /**
    * Connect to the broker. We keep only 1 connection for each connection string provided in config, as advised by RabbitMQ
-   * @return {Promise} A promise that resolve with an amqp.node connection object
+   * @return {Promise<import('amqplib').ChannelModel>} A promise that resolve with an amqp.node connection object
    */
   async getConnection() {
     if (this.isClosed) {
@@ -154,6 +164,11 @@ class Connection {
     }
   }
 
+  /**
+   * @param {string} queue
+   * @param {import('./channels').ChannelConfig} config
+   * @return {Promise<import('amqplib').Channel>}
+   */
   async getChannel(queue, config) {
     await this.getConnection();
     // `close()` flips `isClosed` synchronously (before any of its own awaits), so re-checking here,
@@ -167,6 +182,9 @@ class Connection {
     return await this._channels.get(queue, config);
   }
 
+  /**
+   * @return {Promise<import('amqplib').Channel>}
+   */
   async getDefaultChannel() {
     await this.getConnection();
     if (this.isClosed) {
@@ -185,17 +203,24 @@ class Connection {
     channel.on(on, func);
   }
 
+  /** @return {import('../../types/modules/connection').ConnectionConfig} */
   get config() {
     return this._config;
   }
 
+  /** @param {import('../../types/modules/connection').ConnectionConfig} value */
   set config(value) {
     this._config = value;
   }
 }
 
+/** @type {Connection} */
 let instance;
 
+/**
+ * @param {import('../../types/modules/connection').ConnectionConfig} config
+ * @return {Connection}
+ */
 module.exports = (config) => {
   assert(instance || config, 'Connection can not be created because config does not exist');
   assert(config.hostname);

--- a/src/modules/connection.js
+++ b/src/modules/connection.js
@@ -18,14 +18,21 @@ function onConnectionError(error) {
 
 /**
  * Thrown by `getConnection()` once `close()` has been called - the connection is terminally shut
- * down for the process and will never reconnect.
+ * down for the process and will never reconnect. Also used to fail pending work (e.g. RPC waiters)
+ * that a channel/connection close leaves unanswerable, whether that close was requested or not.
  */
 class ConnectionClosedError extends Error {
-  constructor(message = 'Connection is closed') {
+  /**
+   * @param {'shutdown'|'unexpected'} [origin] Whether the connection went away because `close()`
+   *   was called ('shutdown'), or because the socket/channel closed on its own ('unexpected').
+   * @param {string} [message]
+   */
+  constructor(origin = 'shutdown', message = 'Connection is closed') {
     super(message);
 
     this.name = 'ConnectionClosedError';
     this.message = message;
+    this.origin = origin;
 
     Error.captureStackTrace(this, this.constructor);
   }

--- a/src/modules/consumer.js
+++ b/src/modules/consumer.js
@@ -8,9 +8,6 @@ const loggerAlias = 'arnav_mq:consumer';
 
 // How often `drain()` polls `inFlight()` while waiting for in-flight handlers to finish.
 const DRAIN_POLL_INTERVAL_MS = 50;
-// Fallback budget `drain()`/`stop()` give in-flight handlers to finish, only used if the
-// `shutdownTimeout` config value (see src/index.js) is somehow unset.
-const DEFAULT_DRAIN_TIMEOUT_MS = 30000;
 
 class Consumer {
   constructor(connection) {
@@ -47,14 +44,6 @@ class Consumer {
    */
   _isLive(subscription) {
     return !this._shuttingDown && !subscription.cancelled && !this._connection.isClosed;
-  }
-
-  /**
-   * Whether stop()'s timeout path already rejected+requeued this delivery - so acking/rejecting/
-   * RPC-replying to it again would double-handle a message another pod may already be processing.
-   */
-  _isAbandoned(subscription, msg) {
-    return subscription.abandonedMessages.has(msg);
   }
 
   /**
@@ -154,8 +143,7 @@ class Consumer {
       consumerTag: null,
       onChannelClose: null,
       cancelled: false,
-      inFlightMessages: new Set(), // Set<amqp.Message> - tracked so the drain/timeout path has the actual messages to reject, not just a count.
-      abandonedMessages: new Set(), // Set<amqp.Message> - messages requeued by stop()'s timeout path; per-delivery guard against double ack/reject/RPC-reply.
+      inFlightCount: 0, // handlers currently running, not yet acked/rejected.
     };
     this._subscriptions.push(subscription);
 
@@ -264,7 +252,23 @@ class Consumer {
         return;
       }
 
-      subscription.inFlightMessages.add(msg);
+      if (!this._isLive(subscription)) {
+        // Buffered by the broker before cancel-ok landed (prefetch > 1) - hand it straight back
+        // instead of running the handler, so it can't block drain()/stop()/close() on work that
+        // was never going to be allowed to finish here.
+        try {
+          channel.reject(msg, true);
+        } catch (error) {
+          logger.error({
+            message: `${loggerAlias} Failed to reject message received after shutdown on queue ${queue}: ${error.message}`,
+            error,
+            params: { queue },
+          });
+        }
+        return;
+      }
+
+      subscription.inFlightCount += 1;
       try {
         const messageString = msg.content.toString();
         logger.debug({
@@ -284,9 +288,7 @@ class Consumer {
           // Use callback from action in case it was changed/wrapped in the hook (for instance, for instrumentation)
           const res = await action.callback(body, msg.properties);
 
-          if (!this._isAbandoned(subscription, msg)) {
-            await this.checkRpc(msg.properties, queue, res);
-          }
+          await this.checkRpc(msg.properties, queue, res);
         } catch (error) {
           logger.error({
             message: `${loggerAlias} Failed processing message from queue ${queue}: ${error.message}`,
@@ -304,21 +306,17 @@ class Consumer {
           return;
         }
 
-        // Abandoned by stop()'s timeout path: it already rejected this delivery on this channel.
-        // Acking it too would hit amqplib's PRECONDITION_FAILED and close the (shared) channel.
         let ackError;
-        if (!this._isAbandoned(subscription, msg)) {
-          try {
-            channel.ack(msg);
-          } catch (err) {
-            ackError = err;
+        try {
+          channel.ack(msg);
+        } catch (err) {
+          ackError = err;
 
-            logger.error({
-              message: `${loggerAlias} Failed to ack message after processing finished on queue ${queue}: ${ackError.message}`,
-              error: ackError,
-              params: { queue },
-            });
-          }
+          logger.error({
+            message: `${loggerAlias} Failed to ack message after processing finished on queue ${queue}: ${ackError.message}`,
+            error: ackError,
+            params: { queue },
+          });
         }
         await this.hooks.trigger(this, ConsumerHooks.afterProcessMessageEvent, {
           queue,
@@ -327,7 +325,7 @@ class Consumer {
           ackError,
         });
       } finally {
-        subscription.inFlightMessages.delete(msg);
+        subscription.inFlightCount -= 1;
       }
     };
 
@@ -352,22 +350,20 @@ class Consumer {
     const { queue } = subscription;
     let rejectError;
 
-    if (!this._isAbandoned(subscription, msg)) {
-      try {
-        channel.reject(msg, requeue);
+    try {
+      channel.reject(msg, requeue);
 
-        if (!requeue) {
-          // If not requeued and message will be removed from the queue, return rpc error response if needed.
-          await this.checkRpc(msg.properties, queue, error instanceof Error ? { error } : undefined);
-        }
-      } catch (err) {
-        rejectError = err;
-        logger.error({
-          message: `${loggerAlias} Failed to reject message after processing failure on queue ${queue}: ${rejectError.message}`,
-          error: rejectError,
-          params: { queue },
-        });
+      if (!requeue) {
+        // If not requeued and message will be removed from the queue, return rpc error response if needed.
+        await this.checkRpc(msg.properties, queue, error instanceof Error ? { error } : undefined);
       }
+    } catch (err) {
+      rejectError = err;
+      logger.error({
+        message: `${loggerAlias} Failed to reject message after processing failure on queue ${queue}: ${rejectError.message}`,
+        error: rejectError,
+        params: { queue },
+      });
     }
 
     await this.hooks.trigger(this, ConsumerHooks.afterProcessMessageEvent, {
@@ -425,108 +421,39 @@ class Consumer {
   }
 
   /**
-   * Resolves true once every in-flight message handler has finished (inFlight() reaches 0), or
-   * false if `timeoutMs` elapses first. Cancels nothing - pair with `cancel()`/`cancelAll()`.
+   * Resolves once every in-flight message handler has finished (inFlight() reaches 0). Cancels
+   * nothing - pair with `cancel()`/`cancelAll()`. No timeout: a handler that never finishes means
+   * this never resolves, and shutdown is left to the process orchestrator's own kill grace period.
    *
    * Polls `inFlight()` every 50ms rather than resolving off a deferred set in the consume finally
    * block: with a shared channel and prefetch > 1, deliveries already buffered in the socket keep
    * arriving for a few ticks after cancel-ok, and a deferred would resolve on the first momentary
    * zero in between two such deliveries.
-   * @param {number} [timeoutMs] How long to wait for in-flight handlers to finish. Defaults to the
-   *   `shutdownTimeout` config value (30s).
-   * @return {Promise<boolean>} true if drained before the timeout, false otherwise.
+   * @return {Promise<void>}
    */
-  async drain(timeoutMs = this._configuration.shutdownTimeout ?? DEFAULT_DRAIN_TIMEOUT_MS) {
-    const deadline = Date.now() + timeoutMs;
-
+  async drain() {
     while (this.inFlight() > 0) {
-      if (Date.now() >= deadline) {
-        return false;
-      }
       await utils.timeoutPromise(DRAIN_POLL_INTERVAL_MS);
     }
-
-    return true;
   }
 
   /**
-   * cancelAll(), then drain(timeout). Idempotent - repeated calls share the one in-flight
-   * shutdown promise instead of running cancelAll()/drain() more than once.
-   *
-   * If drain() times out, every message still in-flight for every subscription is rejected with
-   * requeue=true (so another pod picks it up) and recorded in that subscription's
-   * `abandonedMessages`, which guards the ack/reject/RPC-reply call sites the still-running
-   * handler will eventually hit. The handler itself is not killed - it keeps running until the
-   * process exits, its work simply duplicated elsewhere, which this system's at-least-once
-   * delivery already assumes.
-   * @param {object} [options]
-   * @param {number} [options.timeout] Passed through to drain(). Defaults to 30s.
-   * @return {Promise<{drained: boolean, abandoned: Record<string, number>}>} `drained` is true if
-   *   every handler finished inside the budget, false if in-flight messages were abandoned.
-   *   `abandoned` maps queue name to how many messages were abandoned on it (empty on a clean drain);
-   *   callers use it to emit an abandoned-message metric.
+   * cancelAll(), then drain(). Idempotent - repeated calls share the one in-flight shutdown
+   * promise instead of running cancelAll()/drain() more than once.
+   * @return {Promise<void>} Resolves once every in-flight handler has finished.
    */
-  async stop(options = {}) {
+  async stop() {
     if (!this._stopPromise) {
-      this._stopPromise = this._stop(options.timeout);
+      this._stopPromise = this._stop();
     }
 
     return await this._stopPromise;
   }
 
   /** @private */
-  async _stop(timeoutMs) {
+  async _stop() {
     await this.cancelAll();
-
-    const drained = await this.drain(timeoutMs);
-    const abandoned = drained ? {} : this._abandonInFlightMessages();
-
-    return { drained, abandoned };
-  }
-
-  /**
-   * @private
-   * @return {Record<string, number>} How many messages were abandoned per queue by this call. Queues
-   *   with nothing in flight are absent, so a clean pass returns `{}`. Two subscriptions on the same
-   *   queue contribute to the same entry.
-   */
-  _abandonInFlightMessages() {
-    const abandoned = {};
-
-    for (const subscription of this._subscriptions) {
-      const { inFlightMessages, channel, queue } = subscription;
-      if (inFlightMessages.size === 0) {
-        continue;
-      }
-
-      const abandonedCount = inFlightMessages.size;
-      abandoned[queue] = (abandoned[queue] || 0) + abandonedCount;
-
-      for (const msg of inFlightMessages) {
-        subscription.abandonedMessages.add(msg);
-
-        if (!channel) {
-          continue;
-        }
-
-        try {
-          channel.reject(msg, true); // requeue -> another pod picks it up
-        } catch (error) {
-          logger.error({
-            message: `${loggerAlias} Failed to reject abandoned in-flight message on queue ${queue}: ${error.message}`,
-            error,
-            params: { queue },
-          });
-        }
-      }
-
-      logger.warn({
-        message: `${loggerAlias} Timed out waiting for in-flight handlers on queue ${queue}; abandoned and requeued ${abandonedCount} message(s)`,
-        params: { queue, count: abandonedCount },
-      });
-    }
-
-    return abandoned;
+    await this.drain();
   }
 
   /**
@@ -534,7 +461,7 @@ class Consumer {
    * @return {number}
    */
   inFlight() {
-    return this._subscriptions.reduce((total, sub) => total + sub.inFlightMessages.size, 0);
+    return this._subscriptions.reduce((total, sub) => total + sub.inFlightCount, 0);
   }
 }
 

--- a/src/modules/consumer.js
+++ b/src/modules/consumer.js
@@ -367,7 +367,7 @@ class Consumer {
     }
 
     if (!this._isLive(subscription)) {
-      await this._rejectAfterShutdown(channel, queue, msg);
+      await this._rejectAfterShutdown(channel, subscription, msg);
       return;
     }
 
@@ -385,20 +385,34 @@ class Consumer {
    * buffered to us before cancel-ok landed (prefetch > 1): running the handler would block
    * `_drain()`/`stop()`/`close()` on work that was never going to be allowed to finish here.
    *
-   * Emits `afterProcessMessageEvent` with `requeued: true` so this does not become a delivery the
+   * Emits the same before/after pair as any other delivery, so this does not become a delivery the
    * per-message instrumentation never hears about - during a rolling deploy that is up to
-   * `prefetch` messages per consumer, and without the event a caller's received and completed
-   * counters silently disagree by exactly that many. No `beforeProcessMessageEvent`: that hook
-   * exists to wrap `action.callback`, and the callback is never going to run here, so instrumentation
-   * that closes its span from inside the wrapper would leak one span per requeued message.
+   * `prefetch` messages per consumer, and without the events a caller's received and completed
+   * counters silently disagree by exactly that many. `afterProcessMessageEvent` carries
+   * `requeued: true` to distinguish it from a message that was actually processed.
    *
-   * Not counted in `inFlightCount`: the reject is already on the wire before the hook runs, so the
-   * message is safely back with the broker and the drain has nothing left to wait for. A slow hook
-   * can be cut off by the connection close that follows.
+   * Both events, not just the after one: instrumentation typically *starts* its span in the before
+   * hook and stores it on the message, and the after hook ends whatever it finds there - so an
+   * after event on its own does nothing at all, and the requeued delivery stays untraced. The
+   * before hook also wraps `action.callback`, which is never invoked here; that is safe as long as
+   * the span is ended from the after hook rather than from inside the wrapper, and it matches the
+   * shape the hook already documents for a `beforeProcessMessage` that skips processing.
+   * `action.content` is absent, since nothing is deserialized on this path.
+   *
+   * Not counted in `inFlightCount`: the reject is already on the wire before the after hook runs,
+   * so the message is safely back with the broker and the drain has nothing left to wait for. A
+   * slow hook can be cut off by the connection close that follows.
    * @private
    * @return {Promise<void>}
    */
-  async _rejectAfterShutdown(channel, queue, msg) {
+  async _rejectAfterShutdown(channel, subscription, msg) {
+    const { queue, callback } = subscription;
+
+    await this.hooks.trigger(this, ConsumerHooks.beforeProcessMessageEvent, {
+      queue,
+      action: { message: msg, content: undefined, callback },
+    });
+
     let rejectError;
     try {
       channel.reject(msg, true);

--- a/src/modules/consumer.js
+++ b/src/modules/consumer.js
@@ -22,6 +22,10 @@ class Consumer {
     // Set by _cancelAll()/stop(): stops resubscribe/retry for every subscription, existing and future.
     this._shuttingDown = false;
     // Memoized stop() promise, so repeated calls share one in-flight shutdown instead of racing.
+    // Not a mode flag - the same idempotency idiom as Connection._closePromise. Without it a
+    // concurrent close() re-runs _cancelAll() and sends basic.cancel for a tag already cancelled,
+    // and the obvious alternatives (an early return on `cancelled`, clearing consumerTag) both
+    // break _consumeQueue's deferred re-cancel for a subscription cancelled mid-flight.
     this._stopPromise = null;
   }
 

--- a/src/modules/consumer.js
+++ b/src/modules/consumer.js
@@ -6,11 +6,26 @@ const { logger } = require('./logger');
 
 const loggerAlias = 'arnav_mq:consumer';
 
+// How often `drain()` polls `inFlight()` while waiting for in-flight handlers to finish.
+const DRAIN_POLL_INTERVAL_MS = 50;
+// Fallback budget `drain()`/`stop()` give in-flight handlers to finish, only used if the
+// `shutdownTimeout` config value (see src/index.js) is somehow unset.
+const DEFAULT_DRAIN_TIMEOUT_MS = 30000;
+
 class Consumer {
   constructor(connection) {
     this._connection = connection;
     this._configuration = this._connection.config;
     this.hooks = new ConsumerHooks();
+
+    // Subscription registry, keyed by an incrementing id (NOT queue name - two consume() calls on
+    // the same queue with different callbacks are legal, and queue-keying would silently drop a
+    // consumerTag).
+    this._subscriptions = [];
+    // Set by cancelAll()/stop(): stops resubscribe/retry for every subscription, existing and future.
+    this._shuttingDown = false;
+    // Memoized stop() promise, so repeated calls share one in-flight shutdown instead of racing.
+    this._stopPromise = null;
   }
 
   set connection(value) {
@@ -20,6 +35,26 @@ class Consumer {
 
   get connection() {
     return this._connection;
+  }
+
+  /**
+   * Whether a subscription is still eligible to (re)subscribe/consume - i.e. neither the consumer
+   * as a whole nor this particular subscription has been told to shut down, and the underlying
+   * connection isn't terminally closed (checked directly so this holds even for a caller that
+   * closes the connection without going through `arnavmq.close()`'s consumer.stop() first).
+   * @param {object} subscription
+   * @return {boolean}
+   */
+  _isLive(subscription) {
+    return !this._shuttingDown && !subscription.cancelled && !this._connection.isClosed;
+  }
+
+  /**
+   * Whether stop()'s timeout path already rejected+requeued this delivery - so acking/rejecting/
+   * RPC-replying to it again would double-handle a message another pod may already be processing.
+   */
+  _isAbandoned(subscription, msg) {
+    return subscription.abandonedMessages.has(msg);
   }
 
   /**
@@ -111,15 +146,41 @@ class Consumer {
       };
     }
 
+    const subscription = {
+      queue,
+      options,
+      callback,
+      channel: null,
+      consumerTag: null,
+      onChannelClose: null,
+      cancelled: false,
+      inFlightMessages: new Set(), // Set<amqp.Message> - tracked so the drain/timeout path has the actual messages to reject, not just a count.
+      abandonedMessages: new Set(), // Set<amqp.Message> - messages requeued by stop()'s timeout path; per-delivery guard against double ack/reject/RPC-reply.
+    };
+    this._subscriptions.push(subscription);
+
+    return await this._subscribe(subscription);
+  }
+
+  async _subscribe(subscription) {
+    if (!this._isLive(subscription)) {
+      return false;
+    }
+
+    const { queue, options } = subscription;
+
     // consumer gets a suffix if one is set on the configuration, to suffix all queues names
     // ex: service-something with suffix :ci becomes service-suffix:ci etc.
     const suffixedQueue = `${queue}${this._connection.config.consumerSuffix || ''}`;
 
-    const channel = await this._initializeChannel(queue, options || {}, callback);
+    const channel = await this._initializeChannel(subscription);
     if (!channel) {
       // in case of any error creating the channel, wait for some time and then try to reconnect again (to avoid overflow)
       await utils.timeoutPromise(this._connection.config.timeout);
-      return await this.subscribe(queue, options, callback);
+      if (!this._isLive(subscription)) {
+        return false;
+      }
+      return await this._subscribe(subscription);
     }
 
     try {
@@ -137,18 +198,43 @@ class Consumer {
       params: { queue },
     });
 
-    await this._consumeQueue(channel, queue, callback);
-    return true;
+    // A cancel()/cancelAll() may have landed while we were awaiting getChannel()/assertQueue() above.
+    // Not required for correctness (the guard after `consumerTag` is set in `_consumeQueue` catches
+    // it either way), it just skips a pointless basic.consume+basic.cancel round-trip pair.
+    if (!this._isLive(subscription)) {
+      return false;
+    }
+
+    await this._consumeQueue(channel, subscription);
+
+    // A cancel() that landed *inside* _consumeQueue() has already been carried out on the broker by
+    // now (see there), so this subscription never really went live - report that, the same way the
+    // guards above do, instead of an unconditional `true`.
+    return this._isLive(subscription);
   }
 
-  async _initializeChannel(queue, options, callback) {
+  async _initializeChannel(subscription) {
+    const { queue, options } = subscription;
     let channel;
     try {
       channel = await this._connection.getChannel(queue, options.channel || {});
-      // when channel is closed, we want to be sure we recreate the queue ASAP so we trigger a reconnect by recreating the consumer
-      channel.addListener('close', () => {
-        this.subscribe(queue, options, callback);
-      });
+
+      // Same shared DEFAULT_CHANNEL object is reused across many subscriptions/reconnects - drop
+      // this subscription's previous listener before adding a new one, or the channel accumulates one
+      // 'close' listener per resubscribe and eventually hits MaxListenersExceededWarning.
+      subscription.channel?.removeListener('close', subscription.onChannelClose);
+
+      const onChannelClose = () => {
+        // when channel is closed, we want to be sure we recreate the queue ASAP so we trigger a reconnect by recreating the consumer
+        if (!this._isLive(subscription)) {
+          return;
+        }
+        this._subscribe(subscription);
+      };
+      channel.addListener('close', onChannelClose);
+      subscription.channel = channel;
+      subscription.onChannelClose = onChannelClose;
+
       return channel;
     } catch (err) {
       if (err instanceof ChannelAlreadyExistsError) {
@@ -171,7 +257,9 @@ class Consumer {
     }
   }
 
-  async _consumeQueue(channel, queue, callback) {
+  async _consumeQueue(channel, subscription) {
+    const { queue, callback } = subscription;
+
     const consumeFunc = async (msg) => {
       if (!msg) {
         // When forcefully cancelled by rabbitmq, consumer would receive a null message.
@@ -184,63 +272,88 @@ class Consumer {
         return;
       }
 
-      const messageString = msg.content.toString();
-      logger.debug({
-        message: `${loggerAlias} [${queue}] < ${messageString}`,
-        params: { queue, message: messageString },
-      });
-
-      let body = {};
+      // amqplib invokes consumeFunc synchronously per delivery, so there is no window where a
+      // message is "received" but untracked.
+      subscription.inFlightMessages.add(msg);
       try {
-        body = parsers.in(msg);
-
-        const action = { message: msg, content: body, callback };
-        await this.hooks.trigger(this, ConsumerHooks.beforeProcessMessageEvent, {
-          queue,
-          action,
-        });
-        // Use callback from action in case it was changed/wrapped in the hook (for instance, for instrumentation)
-        const res = await action.callback(body, msg.properties);
-        await this.checkRpc(msg.properties, queue, res);
-      } catch (error) {
-        logger.error({
-          message: `${loggerAlias} Failed processing message from queue ${queue}: ${error.message}`,
-          error,
+        const messageString = msg.content.toString();
+        logger.debug({
+          message: `${loggerAlias} [${queue}] < ${messageString}`,
           params: { queue, message: messageString },
         });
-        // For callback errors, use default behavior with _rejectMessageAfterProcess
-        let shouldRequeue = this._connection.config.requeue;
-        if (error instanceof SyntaxError) {
-          // For parsing errors, reject the message and don't requeue it.
-          shouldRequeue = false;
+
+        let body = {};
+        try {
+          body = parsers.in(msg);
+
+          const action = { message: msg, content: body, callback };
+          await this.hooks.trigger(this, ConsumerHooks.beforeProcessMessageEvent, {
+            queue,
+            action,
+          });
+          // Use callback from action in case it was changed/wrapped in the hook (for instance, for instrumentation)
+          const res = await action.callback(body, msg.properties);
+
+          // Abandoned by stop()'s timeout path: it already rejected+requeued this delivery, so
+          // another pod may already be replying to this RPC. Replying again would double-reply.
+          if (!this._isAbandoned(subscription, msg)) {
+            await this.checkRpc(msg.properties, queue, res);
+          }
+        } catch (error) {
+          logger.error({
+            message: `${loggerAlias} Failed processing message from queue ${queue}: ${error.message}`,
+            error,
+            params: { queue, message: messageString },
+          });
+          // For callback errors, use default behavior with _rejectMessageAfterProcess
+          let shouldRequeue = this._connection.config.requeue;
+          if (error instanceof SyntaxError) {
+            // For parsing errors, reject the message and don't requeue it.
+            shouldRequeue = false;
+          }
+
+          await this._rejectMessageAfterProcess(channel, subscription, msg, body, shouldRequeue, error);
+          return;
         }
 
-        await this._rejectMessageAfterProcess(channel, queue, msg, body, shouldRequeue, error);
-        return;
-      }
+        // Abandoned by stop()'s timeout path: it already rejected this delivery on this channel.
+        // Acking it too would hit amqplib's PRECONDITION_FAILED and close the (shared) channel.
+        let ackError;
+        if (!this._isAbandoned(subscription, msg)) {
+          try {
+            channel.ack(msg);
+          } catch (err) {
+            ackError = err;
 
-      let ackError;
-      try {
-        channel.ack(msg);
-      } catch (err) {
-        ackError = err;
-
-        logger.error({
-          message: `${loggerAlias} Failed to ack message after processing finished on queue ${queue}: ${ackError.message}`,
-          error: ackError,
-          params: { queue },
+            logger.error({
+              message: `${loggerAlias} Failed to ack message after processing finished on queue ${queue}: ${ackError.message}`,
+              error: ackError,
+              params: { queue },
+            });
+          }
+        }
+        await this.hooks.trigger(this, ConsumerHooks.afterProcessMessageEvent, {
+          queue,
+          message: msg,
+          content: body,
+          ackError,
         });
+      } finally {
+        subscription.inFlightMessages.delete(msg);
       }
-      await this.hooks.trigger(this, ConsumerHooks.afterProcessMessageEvent, {
-        queue,
-        message: msg,
-        content: body,
-        ackError,
-      });
     };
 
     try {
-      await channel.consume(queue, consumeFunc, { noAck: false });
+      const { consumerTag } = await channel.consume(subscription.queue, consumeFunc, { noAck: false });
+      subscription.consumerTag = consumerTag;
+
+      // A cancel()/cancelAll() that landed between _initializeChannel() and this point had no
+      // consumerTag to cancel, so it only set `cancelled` and sent nothing to the broker. Now that
+      // a real tag exists, actually cancel it - otherwise the subscription goes live despite having
+      // been cancelled, and keeps consuming indefinitely on the public cancel() path.
+      if (!this._isLive(subscription)) {
+        await this._cancelSubscription(subscription);
+      }
     } catch (error) {
       logger.error({
         message: `${loggerAlias} Failed to start consuming from queue ${queue}: ${error.message}`,
@@ -251,22 +364,29 @@ class Consumer {
   }
 
   /** @private */
-  async _rejectMessageAfterProcess(channel, queue, msg, parsedBody, requeue, error) {
+  async _rejectMessageAfterProcess(channel, subscription, msg, parsedBody, requeue, error) {
+    const { queue } = subscription;
     let rejectError;
-    try {
-      channel.reject(msg, requeue);
 
-      if (!requeue) {
-        // If not requeued and message will be removed from the queue, return rpc error response if needed.
-        await this.checkRpc(msg.properties, queue, error instanceof Error ? { error } : undefined);
+    // Abandoned by stop()'s timeout path: it already rejected+requeued this delivery. Rejecting
+    // again hits amqplib's PRECONDITION_FAILED (closing the shared channel), and replying again
+    // to the RPC would double-reply alongside whichever pod picked up the requeued message.
+    if (!this._isAbandoned(subscription, msg)) {
+      try {
+        channel.reject(msg, requeue);
+
+        if (!requeue) {
+          // If not requeued and message will be removed from the queue, return rpc error response if needed.
+          await this.checkRpc(msg.properties, queue, error instanceof Error ? { error } : undefined);
+        }
+      } catch (err) {
+        rejectError = err;
+        logger.error({
+          message: `${loggerAlias} Failed to reject message after processing failure on queue ${queue}: ${rejectError.message}`,
+          error: rejectError,
+          params: { queue },
+        });
       }
-    } catch (err) {
-      rejectError = err;
-      logger.error({
-        message: `${loggerAlias} Failed to reject message after processing failure on queue ${queue}: ${rejectError.message}`,
-        error: rejectError,
-        params: { queue },
-      });
     }
 
     await this.hooks.trigger(this, ConsumerHooks.afterProcessMessageEvent, {
@@ -276,6 +396,172 @@ class Consumer {
       error,
       rejectError,
     });
+  }
+
+  /**
+   * basic.cancel by consumerTag for every subscription on `queue`. Does NOT close the channel (it
+   * is shared with other consumers and with RPC replies) and does NOT wait for in-flight handlers
+   * - use `drain()`/`stop()` for that. Cancelled subscriptions are never resubscribed.
+   * @param {string} queue The queue to stop consuming from.
+   * @return {Promise<void>}
+   */
+  async cancel(queue) {
+    const subscriptions = this._subscriptions.filter((sub) => sub.queue === queue);
+    await Promise.all(subscriptions.map((sub) => this._cancelSubscription(sub)));
+  }
+
+  /**
+   * cancel()s every subscription across every queue, and marks this consumer as shutting down so
+   * no subscription resubscribes/retries afterward.
+   * @return {Promise<void>}
+   */
+  async cancelAll() {
+    this._shuttingDown = true;
+    await Promise.all(this._subscriptions.map((sub) => this._cancelSubscription(sub)));
+  }
+
+  /** @private */
+  async _cancelSubscription(subscription) {
+    subscription.cancelled = true;
+
+    // The resubscribe-on-close listener is dead weight once cancelled (it early-returns on the
+    // `cancelled` flag above), and the channel it sits on is shared and long-lived - leaving it
+    // attached leaks one listener per subscribe->cancel cycle, up to MaxListenersExceededWarning.
+    // The subscription itself deliberately stays in `_subscriptions`: `_abandonInFlightMessages()` and
+    // `inFlight()` still need it.
+    if (subscription.onChannelClose) {
+      subscription.channel?.removeListener('close', subscription.onChannelClose);
+    }
+
+    // The subscription may have no consumerTag yet - the broker was down at boot and it is sitting in
+    // the retry loop, or _initializeChannel returned null. Nothing to cancel on the broker; the
+    // `cancelled` flag above is what stops the pending retry from ever consuming.
+    if (!subscription.channel || !subscription.consumerTag) {
+      return;
+    }
+
+    try {
+      await subscription.channel.cancel(subscription.consumerTag);
+    } catch (error) {
+      logger.error({
+        message: `${loggerAlias} Failed to cancel consumer (tag: ${subscription.consumerTag}) for queue ${subscription.queue}: ${error.message}`,
+        error,
+        params: { queue: subscription.queue },
+      });
+    }
+  }
+
+  /**
+   * Resolves true once every in-flight message handler has finished (inFlight() reaches 0), or
+   * false if `timeoutMs` elapses first. Cancels nothing - pair with `cancel()`/`cancelAll()`.
+   *
+   * Polls `inFlight()` every 50ms rather than resolving off a deferred set in the consume finally
+   * block: with a shared channel and prefetch > 1, deliveries already buffered in the socket keep
+   * arriving for a few ticks after cancel-ok, and a deferred would resolve on the first momentary
+   * zero in between two such deliveries.
+   * @param {number} [timeoutMs] How long to wait for in-flight handlers to finish. Defaults to the
+   *   `shutdownTimeout` config value (30s).
+   * @return {Promise<boolean>} true if drained before the timeout, false otherwise.
+   */
+  async drain(timeoutMs = this._configuration.shutdownTimeout ?? DEFAULT_DRAIN_TIMEOUT_MS) {
+    const deadline = Date.now() + timeoutMs;
+
+    while (this.inFlight() > 0) {
+      if (Date.now() >= deadline) {
+        return false;
+      }
+      await utils.timeoutPromise(DRAIN_POLL_INTERVAL_MS);
+    }
+
+    return true;
+  }
+
+  /**
+   * cancelAll(), then drain(timeout). Idempotent - repeated calls share the one in-flight
+   * shutdown promise instead of running cancelAll()/drain() more than once.
+   *
+   * If drain() times out, every message still in-flight for every subscription is rejected with
+   * requeue=true (so another pod picks it up) and recorded in that subscription's
+   * `abandonedMessages`, which guards the ack/reject/RPC-reply call sites the still-running
+   * handler will eventually hit. The handler itself is not killed - it keeps running until the
+   * process exits, its work simply duplicated elsewhere, which this system's at-least-once
+   * delivery already assumes.
+   * @param {object} [options]
+   * @param {number} [options.timeout] Passed through to drain(). Defaults to 30s.
+   * @return {Promise<{drained: boolean, abandoned: Record<string, number>}>} `drained` is true if
+   *   every handler finished inside the budget, false if in-flight messages were abandoned.
+   *   `abandoned` maps queue name to how many messages were abandoned on it (empty on a clean drain);
+   *   callers use it to emit an abandoned-message metric.
+   */
+  async stop(options = {}) {
+    if (!this._stopPromise) {
+      this._stopPromise = this._stop(options.timeout);
+    }
+
+    return await this._stopPromise;
+  }
+
+  /** @private */
+  async _stop(timeoutMs) {
+    await this.cancelAll();
+
+    const drained = await this.drain(timeoutMs);
+    const abandoned = drained ? {} : this._abandonInFlightMessages();
+
+    return { drained, abandoned };
+  }
+
+  /**
+   * @private
+   * @return {Record<string, number>} How many messages were abandoned per queue by this call. Queues
+   *   with nothing in flight are absent, so a clean pass returns `{}`. Two subscriptions on the same
+   *   queue contribute to the same entry.
+   */
+  _abandonInFlightMessages() {
+    const abandoned = {};
+
+    for (const subscription of this._subscriptions) {
+      const { inFlightMessages, channel, queue } = subscription;
+      if (inFlightMessages.size === 0) {
+        continue;
+      }
+
+      const abandonedCount = inFlightMessages.size;
+      abandoned[queue] = (abandoned[queue] || 0) + abandonedCount;
+
+      for (const msg of inFlightMessages) {
+        subscription.abandonedMessages.add(msg);
+
+        if (!channel) {
+          continue;
+        }
+
+        try {
+          channel.reject(msg, true); // requeue -> another pod picks it up
+        } catch (error) {
+          logger.error({
+            message: `${loggerAlias} Failed to reject abandoned in-flight message on queue ${queue}: ${error.message}`,
+            error,
+            params: { queue },
+          });
+        }
+      }
+
+      logger.warn({
+        message: `${loggerAlias} Timed out waiting for in-flight handlers on queue ${queue}; abandoned and requeued ${abandonedCount} message(s)`,
+        params: { queue, count: abandonedCount },
+      });
+    }
+
+    return abandoned;
+  }
+
+  /**
+   * Count of currently in-flight messages (handler running, not yet acked/rejected).
+   * @return {number}
+   */
+  inFlight() {
+    return this._subscriptions.reduce((total, sub) => total + sub.inFlightMessages.size, 0);
   }
 }
 

--- a/src/modules/consumer.js
+++ b/src/modules/consumer.js
@@ -6,7 +6,7 @@ const { logger } = require('./logger');
 
 const loggerAlias = 'arnav_mq:consumer';
 
-// How often `drain()` polls `inFlight()` while waiting for in-flight handlers to finish.
+// How often `_drain()` polls `inFlight()` while waiting for in-flight handlers to finish.
 const DRAIN_POLL_INTERVAL_MS = 50;
 
 class Consumer {
@@ -15,14 +15,11 @@ class Consumer {
     this._configuration = this._connection.config;
     this.hooks = new ConsumerHooks();
 
-    // Subscription registry, keyed by an incrementing id (NOT queue name - two consume() calls on
-    // the same queue with different callbacks are legal, and queue-keying would silently drop a
-    // consumerTag).
+    // One record per subscribe() call, NOT per queue - two subscribe() calls on the same queue with
+    // different callbacks are legal, and each gets its own consumerTag.
     this._subscriptions = [];
-    // Set by _cancelAll()/stop(): stops resubscribe/retry for every subscription, existing and future.
-    this._shuttingDown = false;
-    // Memoized stop() promise, so repeated calls share one in-flight shutdown instead of racing.
-    // Not a mode flag - the same idempotency idiom as Connection._closePromise. Without it a
+    // Memoized stop() promise - the same idiom as Connection._closePromise, and doubling as the
+    // "shutting down" flag that `_isLive` reads. It has to be memoized regardless: without it a
     // concurrent close() re-runs _cancelAll() and sends basic.cancel for a tag already cancelled,
     // and the obvious alternatives (an early return on `cancelled`, clearing consumerTag) both
     // break _consumeQueue's deferred re-cancel for a subscription cancelled mid-flight.
@@ -47,7 +44,7 @@ class Consumer {
    * @return {boolean}
    */
   _isLive(subscription) {
-    return !this._shuttingDown && !subscription.cancelled && !this._connection.isClosed;
+    return !this._stopPromise && !subscription.cancelled && !this._connection.isClosed;
   }
 
   /**
@@ -111,38 +108,17 @@ class Consumer {
    * @param  {Function} callback Callback function executed when a message is received on the queue name, can return a promise
    * @return {Promise}           A promise that resolves when connection is established and consumer is ready
    */
-  /* eslint no-param-reassign: "off" */
   consume(queue, options, callback) {
     return this.subscribe(queue, options, callback);
   }
 
   async subscribe(queue, options, callback) {
-    const defaultOptions = {
-      persistent: true,
-      durable: true,
-      channel: {
-        prefetch: this._configuration.prefetch,
-      },
-    };
-
-    if (typeof options === 'function') {
-      callback = options;
-      options = defaultOptions;
-    } else {
-      options = {
-        ...defaultOptions,
-        ...options,
-        channel: {
-          ...defaultOptions.channel,
-          ...(options.channel || {}),
-        },
-      };
-    }
+    const resolved = this._resolveSubscribeArgs(options, callback);
 
     const subscription = {
       queue,
-      options,
-      callback,
+      options: resolved.options,
+      callback: resolved.callback,
       channel: null,
       consumerTag: null,
       onChannelClose: null,
@@ -152,6 +128,40 @@ class Consumer {
     this._subscriptions.push(subscription);
 
     return await this._subscribe(subscription);
+  }
+
+  /**
+   * Resolves subscribe()'s two call shapes - `(queue, options, callback)` and `(queue, callback)` -
+   * and fills in the defaults, including the channel prefetch.
+   * @param {object|Function} options
+   * @param {Function} callback
+   * @private
+   * @return {{options: object, callback: Function}}
+   */
+  _resolveSubscribeArgs(options, callback) {
+    const defaults = {
+      persistent: true,
+      durable: true,
+      channel: {
+        prefetch: this._configuration.prefetch,
+      },
+    };
+
+    if (typeof options === 'function') {
+      return { options: defaults, callback: options };
+    }
+
+    return {
+      options: {
+        ...defaults,
+        ...options,
+        channel: {
+          ...defaults.channel,
+          ...(options.channel || {}),
+        },
+      },
+      callback,
+    };
   }
 
   async _subscribe(subscription) {
@@ -242,100 +252,12 @@ class Consumer {
   }
 
   async _consumeQueue(channel, subscription) {
-    const { queue, callback } = subscription;
-
-    const consumeFunc = async (msg) => {
-      if (!msg) {
-        // When forcefully cancelled by rabbitmq, consumer would receive a null message.
-        // https://amqp-node.github.io/amqplib/channel_api.html#channel_consume
-        logger.warn({
-          message: `${loggerAlias} Consumer was cancelled by server for queue '${queue}'`,
-          error: null,
-          params: { queue },
-        });
-        return;
-      }
-
-      if (!this._isLive(subscription)) {
-        // Buffered by the broker before cancel-ok landed (prefetch > 1) - hand it straight back
-        // instead of running the handler, so it can't block drain()/stop()/close() on work that
-        // was never going to be allowed to finish here.
-        try {
-          channel.reject(msg, true);
-        } catch (error) {
-          logger.error({
-            message: `${loggerAlias} Failed to reject message received after shutdown on queue ${queue}: ${error.message}`,
-            error,
-            params: { queue },
-          });
-        }
-        return;
-      }
-
-      subscription.inFlightCount += 1;
-      try {
-        const messageString = msg.content.toString();
-        logger.debug({
-          message: `${loggerAlias} [${queue}] < ${messageString}`,
-          params: { queue, message: messageString },
-        });
-
-        let body = {};
-        try {
-          body = parsers.in(msg);
-
-          const action = { message: msg, content: body, callback };
-          await this.hooks.trigger(this, ConsumerHooks.beforeProcessMessageEvent, {
-            queue,
-            action,
-          });
-          // Use callback from action in case it was changed/wrapped in the hook (for instance, for instrumentation)
-          const res = await action.callback(body, msg.properties);
-
-          await this.checkRpc(msg.properties, queue, res);
-        } catch (error) {
-          logger.error({
-            message: `${loggerAlias} Failed processing message from queue ${queue}: ${error.message}`,
-            error,
-            params: { queue, message: messageString },
-          });
-          // For callback errors, use default behavior with _rejectMessageAfterProcess
-          let shouldRequeue = this._connection.config.requeue;
-          if (error instanceof SyntaxError) {
-            // For parsing errors, reject the message and don't requeue it.
-            shouldRequeue = false;
-          }
-
-          await this._rejectMessageAfterProcess(channel, subscription, msg, body, shouldRequeue, error);
-          return;
-        }
-
-        let ackError;
-        try {
-          channel.ack(msg);
-        } catch (err) {
-          ackError = err;
-
-          logger.error({
-            message: `${loggerAlias} Failed to ack message after processing finished on queue ${queue}: ${ackError.message}`,
-            error: ackError,
-            params: { queue },
-          });
-        }
-        await this.hooks.trigger(this, ConsumerHooks.afterProcessMessageEvent, {
-          queue,
-          message: msg,
-          content: body,
-          ackError,
-        });
-      } finally {
-        subscription.inFlightCount -= 1;
-        this._removeIfDone(subscription);
-      }
-    };
+    const { queue } = subscription;
 
     try {
-      const { consumerTag } = await channel.consume(subscription.queue, consumeFunc, { noAck: false });
+      const { consumerTag } = await channel.consume(queue, (msg) => this._onDelivery(channel, subscription, msg), {
+        noAck: false,
+      });
       subscription.consumerTag = consumerTag;
 
       if (!this._isLive(subscription)) {
@@ -348,6 +270,125 @@ class Consumer {
         params: { queue },
       });
     }
+  }
+
+  /**
+   * amqplib's delivery callback for one subscription: the only place `inFlightCount` moves, so
+   * every delivery this consumer accepts is visible to `inFlight()`/`_drain()` for exactly as long
+   * as its handler runs.
+   * @private
+   */
+  async _onDelivery(channel, subscription, msg) {
+    const { queue } = subscription;
+
+    if (!msg) {
+      // When forcefully cancelled by rabbitmq, consumer would receive a null message.
+      // https://amqp-node.github.io/amqplib/channel_api.html#channel_consume
+      logger.warn({
+        message: `${loggerAlias} Consumer was cancelled by server for queue '${queue}'`,
+        error: null,
+        params: { queue },
+      });
+      return;
+    }
+
+    if (!this._isLive(subscription)) {
+      this._rejectAfterShutdown(channel, queue, msg);
+      return;
+    }
+
+    subscription.inFlightCount += 1;
+    try {
+      await this._processMessage(channel, subscription, msg);
+    } finally {
+      subscription.inFlightCount -= 1;
+      this._removeIfDone(subscription);
+    }
+  }
+
+  /**
+   * Hand a delivery back to the broker untouched. Reached for a message the broker had already
+   * buffered to us before cancel-ok landed (prefetch > 1): running the handler would block
+   * `_drain()`/`stop()`/`close()` on work that was never going to be allowed to finish here.
+   * @private
+   */
+  _rejectAfterShutdown(channel, queue, msg) {
+    try {
+      channel.reject(msg, true);
+    } catch (error) {
+      logger.error({
+        message: `${loggerAlias} Failed to reject message received after shutdown on queue ${queue}: ${error.message}`,
+        error,
+        params: { queue },
+      });
+    }
+  }
+
+  /**
+   * Parse one delivery, run the subscription's callback, reply to it if it was an RPC request, and
+   * settle it with the broker - an ack on success, a reject on any failure above.
+   * @private
+   * @return {Promise<void>}
+   */
+  async _processMessage(channel, subscription, msg) {
+    const { queue, callback } = subscription;
+    const messageString = msg.content.toString();
+    logger.debug({
+      message: `${loggerAlias} [${queue}] < ${messageString}`,
+      params: { queue, message: messageString },
+    });
+
+    let body = {};
+    try {
+      body = parsers.in(msg);
+
+      const action = { message: msg, content: body, callback };
+      await this.hooks.trigger(this, ConsumerHooks.beforeProcessMessageEvent, {
+        queue,
+        action,
+      });
+      // Use callback from action in case it was changed/wrapped in the hook (for instance, for instrumentation)
+      const res = await action.callback(body, msg.properties);
+
+      await this.checkRpc(msg.properties, queue, res);
+    } catch (error) {
+      logger.error({
+        message: `${loggerAlias} Failed processing message from queue ${queue}: ${error.message}`,
+        error,
+        params: { queue, message: messageString },
+      });
+      // A parsing error is never requeued - a redelivery of the same bytes fails identically.
+      // Anything else follows the configured requeue behavior.
+      const shouldRequeue = error instanceof SyntaxError ? false : this._connection.config.requeue;
+
+      await this._rejectMessageAfterProcess(channel, subscription, msg, body, shouldRequeue, error);
+      return;
+    }
+
+    await this._ackMessageAfterProcess(channel, queue, msg, body);
+  }
+
+  /** @private */
+  async _ackMessageAfterProcess(channel, queue, msg, parsedBody) {
+    let ackError;
+    try {
+      channel.ack(msg);
+    } catch (error) {
+      ackError = error;
+
+      logger.error({
+        message: `${loggerAlias} Failed to ack message after processing finished on queue ${queue}: ${ackError.message}`,
+        error: ackError,
+        params: { queue },
+      });
+    }
+
+    await this.hooks.trigger(this, ConsumerHooks.afterProcessMessageEvent, {
+      queue,
+      message: msg,
+      content: parsedBody,
+      ackError,
+    });
   }
 
   /** @private */
@@ -381,13 +422,13 @@ class Consumer {
   }
 
   /**
-   * Cancels every subscription across every queue, and marks this consumer as shutting down so
-   * no subscription resubscribes/retries afterward.
+   * Cancels every subscription across every queue. Only ever reached through `stop()`, which has
+   * already set `_stopPromise` - so no subscription, existing or created later, resubscribes or
+   * retries afterward.
    * @private
    * @return {Promise<void>}
    */
   async _cancelAll() {
-    this._shuttingDown = true;
     await Promise.all(this._subscriptions.map((sub) => this._cancelSubscription(sub)));
   }
 
@@ -395,7 +436,8 @@ class Consumer {
   async _cancelSubscription(subscription) {
     subscription.cancelled = true;
     if (subscription.onChannelClose) {
-      // Does nothing if the subscription is already cancelled
+      // Guarded because removeListener() rejects an undefined listener - there is none to remove
+      // until _initializeChannel has attached one.
       subscription.channel?.removeListener('close', subscription.onChannelClose);
     }
 
@@ -456,6 +498,10 @@ class Consumer {
    * _cancelAll(), then _drain(). Idempotent - repeated calls share the one in-flight shutdown
    * promise instead of running those steps more than once. Internal - not part of the object
    * arnavmq.js's factory returns publicly; call `close()` on the top-level module instead.
+   *
+   * `_stopPromise` is also what `_isLive` reads, so nothing here may consult `_isLive` before the
+   * assignment below completes - the steps' own synchronous prefixes run first, as the right-hand
+   * side of it.
    * @return {Promise<void>} Resolves once every in-flight handler has finished.
    */
   async stop() {

--- a/src/modules/consumer.js
+++ b/src/modules/consumer.js
@@ -326,6 +326,7 @@ class Consumer {
         });
       } finally {
         subscription.inFlightCount -= 1;
+        this._removeIfDone(subscription);
       }
     };
 
@@ -406,6 +407,26 @@ class Consumer {
         error,
         params: { queue: subscription.queue },
       });
+    }
+
+    this._removeIfDone(subscription);
+  }
+
+  /**
+   * Drops a cancelled, fully-drained subscription from `_subscriptions` - otherwise repeated
+   * cancel/re-subscribe cycles in a long-lived process grow the registry (and its retained
+   * callbacks/options/channel references) without bound.
+   * @private
+   * @param {object} subscription
+   */
+  _removeIfDone(subscription) {
+    if (!subscription.cancelled || subscription.inFlightCount > 0) {
+      return;
+    }
+
+    const index = this._subscriptions.indexOf(subscription);
+    if (index !== -1) {
+      this._subscriptions.splice(index, 1);
     }
   }
 

--- a/src/modules/consumer.js
+++ b/src/modules/consumer.js
@@ -1,4 +1,5 @@
 const { ChannelAlreadyExistsError } = require('./channels');
+const { ConnectionClosedError } = require('./connection');
 const { ConsumerHooks } = require('./hooks');
 const parsers = require('./message-parsers');
 const utils = require('./utils');
@@ -106,13 +107,27 @@ class Consumer {
    * @param  {string}   queue    The RabbitMQ queue name
    * @param  {object}   options  (Optional) Options for the queue (durable, persistent, etc.) and channel (with prefetch, `{ channel: { prefetch: 100 } }`)
    * @param  {Function} callback Callback function executed when a message is received on the queue name, can return a promise
-   * @return {Promise}           A promise that resolves when connection is established and consumer is ready
+   * @return {Promise<boolean>}  Resolves `true` once the broker has confirmed the consumer
+   *   (basic.consume-ok), or `false` if the subscription was cancelled before that. Failures that
+   *   may still clear - the channel cannot be opened, the queue cannot be declared as asked - are
+   *   retried behind `config.timeout` rather than resolved, so this stays pending while a queue is
+   *   undeclarable and never reports success for a subscription that is not consuming.
+   *   Rejects with `ConnectionClosedError` if the connection has already been closed.
    */
   consume(queue, options, callback) {
     return this.subscribe(queue, options, callback);
   }
 
   async subscribe(queue, options, callback) {
+    // Shutdown is terminal for the process, and both this consumer and the connection hand back the
+    // same memoized instance on a repeat require+configure - so a subscribe after it can never
+    // start consuming. Rejecting keeps that consistent with `publish()`, which already fails with
+    // ConnectionClosedError; resolving `false` here (as this used to) let a service boot
+    // "successfully", report healthy, and consume nothing for the rest of its life.
+    if (this._stopPromise || this._connection.isClosed) {
+      throw new ConnectionClosedError();
+    }
+
     const resolved = this._resolveSubscribeArgs(options, callback);
 
     const subscription = {
@@ -169,30 +184,11 @@ class Consumer {
       return false;
     }
 
-    const { queue, options } = subscription;
-
-    // consumer gets a suffix if one is set on the configuration, to suffix all queues names
-    // ex: service-something with suffix :ci becomes service-suffix:ci etc.
-    const suffixedQueue = `${queue}${this._connection.config.consumerSuffix || ''}`;
+    const { queue } = subscription;
 
     const channel = await this._initializeChannel(subscription);
-    if (!channel) {
-      // in case of any error creating the channel, wait for some time and then try to reconnect again (to avoid overflow)
-      await utils.timeoutPromise(this._connection.config.timeout);
-      if (!this._isLive(subscription)) {
-        return false;
-      }
-      return await this._subscribe(subscription);
-    }
-
-    try {
-      await channel.assertQueue(suffixedQueue, options);
-    } catch (error) {
-      logger.error({
-        message: `${loggerAlias} Failed to assert queue ${queue}: ${error.message}`,
-        error,
-        params: { queue },
-      });
+    if (!channel || !(await this._assertQueue(channel, subscription))) {
+      return await this._retrySubscribe(subscription);
     }
 
     logger.debug({
@@ -204,10 +200,71 @@ class Consumer {
       return false;
     }
 
-    await this._consumeQueue(channel, subscription);
+    if (!(await this._consumeQueue(channel, subscription))) {
+      // No retry from here, unlike the failures above: a refused basic.consume (an exclusive-consumer
+      // conflict, ACCESS_REFUSED on the consume itself) is about this consumer rather than the
+      // channel, so the caller gets an honest `false` instead of this hammering the broker. If the
+      // channel died with it, its own 'close' still drives a resubscribe - behind the backoff now.
+      return false;
+    }
 
     // A cancel() that landed *inside* _consumeQueue() might have already been carried out on the broker in a race
     return this._isLive(subscription);
+  }
+
+  /**
+   * Declare the queue this subscription consumes from.
+   *
+   * A refusal is not cosmetic: the broker answers a bad declaration (PRECONDITION_FAILED from
+   * changed queue arguments, ACCESS_REFUSED) with a channel-level error, which kills the channel -
+   * so consuming on it afterwards cannot work either. Reporting the failure is what routes the
+   * subscription to `_retrySubscribe()` instead of letting it fall through to a dead
+   * `basic.consume` and then report success.
+   * @private
+   * @return {Promise<boolean>} Whether the queue is declared and the channel still usable.
+   */
+  async _assertQueue(channel, subscription) {
+    const { queue, options } = subscription;
+    // consumer gets a suffix if one is set on the configuration, to suffix all queues names
+    // ex: service-something with suffix :ci becomes service-suffix:ci etc.
+    const suffixedQueue = `${queue}${this._connection.config.consumerSuffix || ''}`;
+
+    try {
+      await channel.assertQueue(suffixedQueue, options);
+      return true;
+    } catch (error) {
+      logger.error({
+        message: `${loggerAlias} Failed to assert queue ${queue}: ${error.message}`,
+        error,
+        params: { queue },
+      });
+      return false;
+    }
+  }
+
+  /**
+   * Wait out the configured backoff, then start the whole subscribe over.
+   *
+   * Reached when there is no usable channel to consume on at all - none could be opened, or the
+   * queue could not be declared as asked, which is a channel-level error and kills the channel with
+   * it. Retrying is the only thing that can ever make such a subscription live, so this keeps going
+   * for as long as it takes and `subscribe()` stays pending: a service awaiting it does not come up,
+   * rather than reporting ready while consuming nothing.
+   *
+   * This is the only retry driver for a subscription that never reached a consumerTag (see
+   * `_initializeChannel`'s close listener), which is what bounds it. Previously only a channel that
+   * failed to *open* was delayed here: an `assertQueue` that killed the channel fell through to a
+   * dead `basic.consume`, and the channel's own 'close' then resubscribed with no delay at all -
+   * a fresh channel per broker round-trip, for as long as the queue stayed undeclarable.
+   * @private
+   * @return {Promise<boolean>}
+   */
+  async _retrySubscribe(subscription) {
+    await utils.timeoutPromise(this._connection.config.timeout);
+    if (!this._isLive(subscription)) {
+      return false;
+    }
+    return await this._subscribe(subscription);
   }
 
   async _initializeChannel(subscription) {
@@ -221,6 +278,16 @@ class Consumer {
 
       const onChannelClose = () => {
         if (!this._isLive(subscription)) {
+          return;
+        }
+        // Only a subscription that got as far as consuming resubscribes from here. Without a
+        // consumerTag this close is the *setup* failing - a queue that cannot be declared as asked
+        // is answered with a channel-level error, which kills the channel and lands straight back
+        // here - and that case belongs to `_retrySubscribe`, which owns the backoff. Letting both
+        // drive it would put two retry loops on one subscription, each opening a channel whose
+        // death starts another, doubling every cycle. A genuine reconnect has a tag and is
+        // unaffected: it still resubscribes immediately.
+        if (!subscription.consumerTag) {
           return;
         }
         this._subscribe(subscription);
@@ -251,6 +318,11 @@ class Consumer {
     }
   }
 
+  /**
+   * Register the delivery callback with the broker.
+   * @private
+   * @return {Promise<boolean>} Whether the broker confirmed the consumer (basic.consume-ok).
+   */
   async _consumeQueue(channel, subscription) {
     const { queue } = subscription;
 
@@ -263,12 +335,14 @@ class Consumer {
       if (!this._isLive(subscription)) {
         await this._cancelSubscription(subscription);
       }
+      return true;
     } catch (error) {
       logger.error({
         message: `${loggerAlias} Failed to start consuming from queue ${queue}: ${error.message}`,
         error,
         params: { queue },
       });
+      return false;
     }
   }
 
@@ -293,7 +367,7 @@ class Consumer {
     }
 
     if (!this._isLive(subscription)) {
-      this._rejectAfterShutdown(channel, queue, msg);
+      await this._rejectAfterShutdown(channel, queue, msg);
       return;
     }
 
@@ -310,18 +384,39 @@ class Consumer {
    * Hand a delivery back to the broker untouched. Reached for a message the broker had already
    * buffered to us before cancel-ok landed (prefetch > 1): running the handler would block
    * `_drain()`/`stop()`/`close()` on work that was never going to be allowed to finish here.
+   *
+   * Emits `afterProcessMessageEvent` with `requeued: true` so this does not become a delivery the
+   * per-message instrumentation never hears about - during a rolling deploy that is up to
+   * `prefetch` messages per consumer, and without the event a caller's received and completed
+   * counters silently disagree by exactly that many. No `beforeProcessMessageEvent`: that hook
+   * exists to wrap `action.callback`, and the callback is never going to run here, so instrumentation
+   * that closes its span from inside the wrapper would leak one span per requeued message.
+   *
+   * Not counted in `inFlightCount`: the reject is already on the wire before the hook runs, so the
+   * message is safely back with the broker and the drain has nothing left to wait for. A slow hook
+   * can be cut off by the connection close that follows.
    * @private
+   * @return {Promise<void>}
    */
-  _rejectAfterShutdown(channel, queue, msg) {
+  async _rejectAfterShutdown(channel, queue, msg) {
+    let rejectError;
     try {
       channel.reject(msg, true);
     } catch (error) {
+      rejectError = error;
       logger.error({
         message: `${loggerAlias} Failed to reject message received after shutdown on queue ${queue}: ${error.message}`,
         error,
         params: { queue },
       });
     }
+
+    await this.hooks.trigger(this, ConsumerHooks.afterProcessMessageEvent, {
+      queue,
+      message: msg,
+      requeued: true,
+      rejectError,
+    });
   }
 
   /**
@@ -481,10 +576,11 @@ class Consumer {
    * nothing - pair with `stop()`. No timeout: a handler that never finishes means
    * this never resolves, and shutdown is left to the process orchestrator's own kill grace period.
    *
-   * Polls `inFlight()` every 50ms rather than resolving off a deferred set in the consume finally
-   * block: with a shared channel and prefetch > 1, deliveries already buffered in the socket keep
-   * arriving for a few ticks after cancel-ok, and a deferred would resolve on the first momentary
-   * zero in between two such deliveries.
+   * Polling is safe only because this is unreachable except through `stop()`, which cancels first:
+   * once cancelled, a delivery the broker had already buffered takes the reject path without ever
+   * incrementing, so `inFlight()` is monotonically non-increasing by the time this runs and any
+   * observed zero is final. On a live, uncancelled subscription it would exit on the first poll
+   * that happened to land between two deliveries - which is why it is private and paired.
    * @private
    * @return {Promise<void>}
    */

--- a/src/modules/consumer.js
+++ b/src/modules/consumer.js
@@ -19,7 +19,7 @@ class Consumer {
     // the same queue with different callbacks are legal, and queue-keying would silently drop a
     // consumerTag).
     this._subscriptions = [];
-    // Set by cancelAll()/stop(): stops resubscribe/retry for every subscription, existing and future.
+    // Set by _cancelAll()/stop(): stops resubscribe/retry for every subscription, existing and future.
     this._shuttingDown = false;
     // Memoized stop() promise, so repeated calls share one in-flight shutdown instead of racing.
     this._stopPromise = null;
@@ -376,23 +376,12 @@ class Consumer {
   }
 
   /**
-   * basic.cancel by consumerTag for every subscription on `queue`. Does NOT close the channel (it
-   * is shared with other consumers and with RPC replies) and does NOT wait for in-flight handlers
-   * - use `drain()`/`stop()` for that. Cancelled subscriptions are never resubscribed.
-   * @param {string} queue The queue to stop consuming from.
-   * @return {Promise<void>}
-   */
-  async cancel(queue) {
-    const subscriptions = this._subscriptions.filter((sub) => sub.queue === queue);
-    await Promise.all(subscriptions.map((sub) => this._cancelSubscription(sub)));
-  }
-
-  /**
-   * cancel()s every subscription across every queue, and marks this consumer as shutting down so
+   * Cancels every subscription across every queue, and marks this consumer as shutting down so
    * no subscription resubscribes/retries afterward.
+   * @private
    * @return {Promise<void>}
    */
-  async cancelAll() {
+  async _cancelAll() {
     this._shuttingDown = true;
     await Promise.all(this._subscriptions.map((sub) => this._cancelSubscription(sub)));
   }
@@ -422,38 +411,37 @@ class Consumer {
 
   /**
    * Resolves once every in-flight message handler has finished (inFlight() reaches 0). Cancels
-   * nothing - pair with `cancel()`/`cancelAll()`. No timeout: a handler that never finishes means
+   * nothing - pair with `stop()`. No timeout: a handler that never finishes means
    * this never resolves, and shutdown is left to the process orchestrator's own kill grace period.
    *
    * Polls `inFlight()` every 50ms rather than resolving off a deferred set in the consume finally
    * block: with a shared channel and prefetch > 1, deliveries already buffered in the socket keep
    * arriving for a few ticks after cancel-ok, and a deferred would resolve on the first momentary
    * zero in between two such deliveries.
+   * @private
    * @return {Promise<void>}
    */
-  async drain() {
+  async _drain() {
     while (this.inFlight() > 0) {
       await utils.timeoutPromise(DRAIN_POLL_INTERVAL_MS);
     }
   }
 
   /**
-   * cancelAll(), then drain(). Idempotent - repeated calls share the one in-flight shutdown
-   * promise instead of running cancelAll()/drain() more than once.
+   * _cancelAll(), then _drain(). Idempotent - repeated calls share the one in-flight shutdown
+   * promise instead of running those steps more than once. Internal - not part of the object
+   * arnavmq.js's factory returns publicly; call `close()` on the top-level module instead.
    * @return {Promise<void>} Resolves once every in-flight handler has finished.
    */
   async stop() {
     if (!this._stopPromise) {
-      this._stopPromise = this._stop();
+      this._stopPromise = (async () => {
+        await this._cancelAll();
+        await this._drain();
+      })();
     }
 
     return await this._stopPromise;
-  }
-
-  /** @private */
-  async _stop() {
-    await this.cancelAll();
-    await this.drain();
   }
 
   /**

--- a/src/modules/consumer.js
+++ b/src/modules/consumer.js
@@ -198,18 +198,13 @@ class Consumer {
       params: { queue },
     });
 
-    // A cancel()/cancelAll() may have landed while we were awaiting getChannel()/assertQueue() above.
-    // Not required for correctness (the guard after `consumerTag` is set in `_consumeQueue` catches
-    // it either way), it just skips a pointless basic.consume+basic.cancel round-trip pair.
     if (!this._isLive(subscription)) {
       return false;
     }
 
     await this._consumeQueue(channel, subscription);
 
-    // A cancel() that landed *inside* _consumeQueue() has already been carried out on the broker by
-    // now (see there), so this subscription never really went live - report that, the same way the
-    // guards above do, instead of an unconditional `true`.
+    // A cancel() that landed *inside* _consumeQueue() might have already been carried out on the broker in a race
     return this._isLive(subscription);
   }
 
@@ -219,13 +214,10 @@ class Consumer {
     try {
       channel = await this._connection.getChannel(queue, options.channel || {});
 
-      // Same shared DEFAULT_CHANNEL object is reused across many subscriptions/reconnects - drop
-      // this subscription's previous listener before adding a new one, or the channel accumulates one
-      // 'close' listener per resubscribe and eventually hits MaxListenersExceededWarning.
+      //If the channel is reused, it could already have a listener. Remove it to avoid multiple listeners on the same channel.
       subscription.channel?.removeListener('close', subscription.onChannelClose);
 
       const onChannelClose = () => {
-        // when channel is closed, we want to be sure we recreate the queue ASAP so we trigger a reconnect by recreating the consumer
         if (!this._isLive(subscription)) {
           return;
         }
@@ -272,8 +264,6 @@ class Consumer {
         return;
       }
 
-      // amqplib invokes consumeFunc synchronously per delivery, so there is no window where a
-      // message is "received" but untracked.
       subscription.inFlightMessages.add(msg);
       try {
         const messageString = msg.content.toString();
@@ -294,8 +284,6 @@ class Consumer {
           // Use callback from action in case it was changed/wrapped in the hook (for instance, for instrumentation)
           const res = await action.callback(body, msg.properties);
 
-          // Abandoned by stop()'s timeout path: it already rejected+requeued this delivery, so
-          // another pod may already be replying to this RPC. Replying again would double-reply.
           if (!this._isAbandoned(subscription, msg)) {
             await this.checkRpc(msg.properties, queue, res);
           }
@@ -347,10 +335,6 @@ class Consumer {
       const { consumerTag } = await channel.consume(subscription.queue, consumeFunc, { noAck: false });
       subscription.consumerTag = consumerTag;
 
-      // A cancel()/cancelAll() that landed between _initializeChannel() and this point had no
-      // consumerTag to cancel, so it only set `cancelled` and sent nothing to the broker. Now that
-      // a real tag exists, actually cancel it - otherwise the subscription goes live despite having
-      // been cancelled, and keeps consuming indefinitely on the public cancel() path.
       if (!this._isLive(subscription)) {
         await this._cancelSubscription(subscription);
       }
@@ -368,9 +352,6 @@ class Consumer {
     const { queue } = subscription;
     let rejectError;
 
-    // Abandoned by stop()'s timeout path: it already rejected+requeued this delivery. Rejecting
-    // again hits amqplib's PRECONDITION_FAILED (closing the shared channel), and replying again
-    // to the RPC would double-reply alongside whichever pod picked up the requeued message.
     if (!this._isAbandoned(subscription, msg)) {
       try {
         channel.reject(msg, requeue);
@@ -423,19 +404,11 @@ class Consumer {
   /** @private */
   async _cancelSubscription(subscription) {
     subscription.cancelled = true;
-
-    // The resubscribe-on-close listener is dead weight once cancelled (it early-returns on the
-    // `cancelled` flag above), and the channel it sits on is shared and long-lived - leaving it
-    // attached leaks one listener per subscribe->cancel cycle, up to MaxListenersExceededWarning.
-    // The subscription itself deliberately stays in `_subscriptions`: `_abandonInFlightMessages()` and
-    // `inFlight()` still need it.
     if (subscription.onChannelClose) {
+      // Does nothing if the subscription is already cancelled
       subscription.channel?.removeListener('close', subscription.onChannelClose);
     }
 
-    // The subscription may have no consumerTag yet - the broker was down at boot and it is sitting in
-    // the retry loop, or _initializeChannel returned null. Nothing to cancel on the broker; the
-    // `cancelled` flag above is what stops the pending retry from ever consuming.
     if (!subscription.channel || !subscription.consumerTag) {
       return;
     }

--- a/src/modules/consumer.js
+++ b/src/modules/consumer.js
@@ -10,6 +10,18 @@ const loggerAlias = 'arnav_mq:consumer';
 // How often `_drain()` polls `inFlight()` while waiting for in-flight handlers to finish.
 const DRAIN_POLL_INTERVAL_MS = 50;
 
+/**
+ * @typedef {Object} Subscription
+ * @property {string} queue
+ * @property {object} options
+ * @property {Function} callback
+ * @property {import('amqplib').Channel|null} channel
+ * @property {string|null} consumerTag
+ * @property {Function|null} onChannelClose
+ * @property {boolean} cancelled
+ * @property {number} inFlightCount handlers currently running, not yet acked/rejected.
+ */
+
 class Consumer {
   constructor(connection) {
     this._connection = connection;
@@ -18,6 +30,7 @@ class Consumer {
 
     // One record per subscribe() call, NOT per queue - two subscribe() calls on the same queue with
     // different callbacks are legal, and each gets its own consumerTag.
+    /** @type {Subscription[]} */
     this._subscriptions = [];
     // Memoized stop() promise - the same idiom as Connection._closePromise, and doubling as the
     // "shutting down" flag that `_isLive` reads. It has to be memoized regardless: without it a
@@ -41,7 +54,7 @@ class Consumer {
    * as a whole nor this particular subscription has been told to shut down, and the underlying
    * connection isn't terminally closed (checked directly so this holds even for a caller that
    * closes the connection without going through `arnavmq.close()`'s consumer.stop() first).
-   * @param {object} subscription
+   * @param {Subscription} subscription
    * @return {boolean}
    */
   _isLive(subscription) {
@@ -572,7 +585,7 @@ class Consumer {
    * cancel/re-subscribe cycles in a long-lived process grow the registry (and its retained
    * callbacks/options/channel references) without bound.
    * @private
-   * @param {object} subscription
+   * @param {Subscription} subscription
    */
   _removeIfDone(subscription) {
     if (!subscription.cancelled || subscription.inFlightCount > 0) {

--- a/src/modules/consumer.js
+++ b/src/modules/consumer.js
@@ -23,9 +23,15 @@ const DRAIN_POLL_INTERVAL_MS = 50;
  */
 
 class Consumer {
+  /**
+   * @param {import('./connection').Connection} connection
+   */
   constructor(connection) {
+    /** @type {import('./connection').Connection} */
     this._connection = connection;
+    /** @type {import('./connection').ConnectionConfig} */
     this._configuration = this._connection.config;
+    /** @type {ConsumerHooks} */
     this.hooks = new ConsumerHooks();
 
     // One record per subscribe() call, NOT per queue - two subscribe() calls on the same queue with
@@ -37,14 +43,17 @@ class Consumer {
     // concurrent close() re-runs _cancelAll() and sends basic.cancel for a tag already cancelled,
     // and the obvious alternatives (an early return on `cancelled`, clearing consumerTag) both
     // break _consumeQueue's deferred re-cancel for a subscription cancelled mid-flight.
+    /** @type {Promise<void>|null} */
     this._stopPromise = null;
   }
 
+  /** @param {import('./connection').Connection} value */
   set connection(value) {
     this._connection = value;
     this._configuration = value.config;
   }
 
+  /** @return {import('./connection').Connection} */
   get connection() {
     return this._connection;
   }
@@ -62,11 +71,12 @@ class Consumer {
   }
 
   /**
-   * Get a function to execute on incoming messages to handle RPC
-   * @param  {any} messageProperties   An amqp.node message properties object, containing the rpc settings
+   * Sends the RPC reply to the response queue according to the message properties when required.
+   * @param  {import('amqplib').MessageProperties} messageProperties An amqp.node message properties object, containing the rpc settings
    * @param  {string} queue The initial queue on which the handler received the message
-   * @param  {any} reply the received message to reply the rpc if needed:
-   * @return {any}       object, string, number... the current received message
+   * @param  {unknown} reply the received message to reply the rpc if needed:
+   * @return {Promise<boolean|import('amqplib').MessageProperties>} The message properties if it is
+   *   not an rpc request, or a boolean indicating the produce result when an rpc response was produced.
    */
   async checkRpc(messageProperties, queue, reply) {
     if (!messageProperties.replyTo) {
@@ -118,8 +128,8 @@ class Consumer {
    * Create a durable queue on RabbitMQ and consumes messages from it - executing a callback function.
    * Automatically answers with the callback response (can be a Promise)
    * @param  {string}   queue    The RabbitMQ queue name
-   * @param  {object}   options  (Optional) Options for the queue (durable, persistent, etc.) and channel (with prefetch, `{ channel: { prefetch: 100 } }`)
-   * @param  {Function} callback Callback function executed when a message is received on the queue name, can return a promise
+   * @param  {object|Function}   options  (Optional) Options for the queue (durable, persistent, etc.) and channel (with prefetch, `{ channel: { prefetch: 100 } }`), or the callback when omitted
+   * @param  {Function} [callback] Callback function executed when a message is received on the queue name, can return a promise
    * @return {Promise<boolean>}  Resolves `true` once the broker has confirmed the consumer
    *   (basic.consume-ok), or `false` if the subscription was cancelled before that. Failures that
    *   may still clear - the channel cannot be opened, the queue cannot be declared as asked - are
@@ -131,6 +141,12 @@ class Consumer {
     return this.subscribe(queue, options, callback);
   }
 
+  /**
+   * @param {string} queue
+   * @param {object|Function} options
+   * @param {Function} [callback]
+   * @return {Promise<boolean>}
+   */
   async subscribe(queue, options, callback) {
     // Shutdown is terminal for the process, and both this consumer and the connection hand back the
     // same memoized instance on a repeat require+configure - so a subscribe after it can never
@@ -192,6 +208,11 @@ class Consumer {
     };
   }
 
+  /**
+   * @private
+   * @param {Subscription} subscription
+   * @return {Promise<boolean>}
+   */
   async _subscribe(subscription) {
     if (!this._isLive(subscription)) {
       return false;
@@ -234,6 +255,8 @@ class Consumer {
    * subscription to `_retrySubscribe()` instead of letting it fall through to a dead
    * `basic.consume` and then report success.
    * @private
+   * @param {import('amqplib').Channel} channel
+   * @param {Subscription} subscription
    * @return {Promise<boolean>} Whether the queue is declared and the channel still usable.
    */
   async _assertQueue(channel, subscription) {
@@ -270,6 +293,7 @@ class Consumer {
    * dead `basic.consume`, and the channel's own 'close' then resubscribed with no delay at all -
    * a fresh channel per broker round-trip, for as long as the queue stayed undeclarable.
    * @private
+   * @param {Subscription} subscription
    * @return {Promise<boolean>}
    */
   async _retrySubscribe(subscription) {
@@ -280,6 +304,11 @@ class Consumer {
     return await this._subscribe(subscription);
   }
 
+  /**
+   * @private
+   * @param {Subscription} subscription
+   * @return {Promise<import('amqplib').Channel|null>}
+   */
   async _initializeChannel(subscription) {
     const { queue, options } = subscription;
     let channel;
@@ -334,6 +363,8 @@ class Consumer {
   /**
    * Register the delivery callback with the broker.
    * @private
+   * @param {import('amqplib').Channel} channel
+   * @param {Subscription} subscription
    * @return {Promise<boolean>} Whether the broker confirmed the consumer (basic.consume-ok).
    */
   async _consumeQueue(channel, subscription) {
@@ -364,6 +395,10 @@ class Consumer {
    * every delivery this consumer accepts is visible to `inFlight()`/`_drain()` for exactly as long
    * as its handler runs.
    * @private
+   * @param {import('amqplib').Channel} channel
+   * @param {Subscription} subscription
+   * @param {import('amqplib').Message|null} msg
+   * @return {Promise<void>}
    */
   async _onDelivery(channel, subscription, msg) {
     const { queue } = subscription;
@@ -416,6 +451,9 @@ class Consumer {
    * so the message is safely back with the broker and the drain has nothing left to wait for. A
    * slow hook can be cut off by the connection close that follows.
    * @private
+   * @param {import('amqplib').Channel} channel
+   * @param {Subscription} subscription
+   * @param {import('amqplib').Message} msg
    * @return {Promise<void>}
    */
   async _rejectAfterShutdown(channel, subscription, msg) {
@@ -450,6 +488,9 @@ class Consumer {
    * Parse one delivery, run the subscription's callback, reply to it if it was an RPC request, and
    * settle it with the broker - an ack on success, a reject on any failure above.
    * @private
+   * @param {import('amqplib').Channel} channel
+   * @param {Subscription} subscription
+   * @param {import('amqplib').Message} msg
    * @return {Promise<void>}
    */
   async _processMessage(channel, subscription, msg) {
@@ -490,7 +531,14 @@ class Consumer {
     await this._ackMessageAfterProcess(channel, queue, msg, body);
   }
 
-  /** @private */
+  /**
+   * @private
+   * @param {import('amqplib').Channel} channel
+   * @param {string} queue
+   * @param {import('amqplib').Message} msg
+   * @param {unknown} parsedBody
+   * @return {Promise<void>}
+   */
   async _ackMessageAfterProcess(channel, queue, msg, parsedBody) {
     let ackError;
     try {
@@ -513,7 +561,16 @@ class Consumer {
     });
   }
 
-  /** @private */
+  /**
+   * @private
+   * @param {import('amqplib').Channel} channel
+   * @param {Subscription} subscription
+   * @param {import('amqplib').Message} msg
+   * @param {unknown} parsedBody
+   * @param {boolean} requeue
+   * @param {Error} error
+   * @return {Promise<void>}
+   */
   async _rejectMessageAfterProcess(channel, subscription, msg, parsedBody, requeue, error) {
     const { queue } = subscription;
     let rejectError;
@@ -554,7 +611,11 @@ class Consumer {
     await Promise.all(this._subscriptions.map((sub) => this._cancelSubscription(sub)));
   }
 
-  /** @private */
+  /**
+   * @private
+   * @param {Subscription} subscription
+   * @return {Promise<void>}
+   */
   async _cancelSubscription(subscription) {
     subscription.cancelled = true;
     if (subscription.onChannelClose) {

--- a/src/modules/hooks/consumer_hooks.js
+++ b/src/modules/hooks/consumer_hooks.js
@@ -8,6 +8,10 @@ class ConsumerHooks extends BaseHooks {
    * - message - The raw amqplib message.
    * - content - The deserialized message content.
    * The hook callback can return `false` in order to skip the message processing, rejecting it and jumping right to the "after process" hook.
+   * The processing callback is therefore not guaranteed to run after this event: it is also skipped
+   * for a message requeued during shutdown (see `requeued` on the "after process" hook). Anything
+   * this hook opens must be closed from the "after process" event rather than from a wrapper around
+   * `action.callback`, which in those cases is never invoked. `action.content` is absent then too.
    * @param {Function | Function[]} callback A callback or callbacks array to register.
    */
   beforeProcessMessage(callback) {
@@ -31,8 +35,8 @@ class ConsumerHooks extends BaseHooks {
    * - requeued - True when the message was handed straight back to the broker without the handler
    *   running at all, because the subscription had already been cancelled - a delivery the broker
    *   had buffered to us before cancel-ok landed, which happens for up to `prefetch` messages per
-   *   consumer on every shutdown. `content` is absent for these (nothing was deserialized) and no
-   *   "before process" event was emitted, since the processing callback is never invoked.
+   *   consumer on every shutdown. A "before process" event is emitted for these as usual, so a span
+   *   started there is still ended here; `content` is absent, since nothing was deserialized.
    * @param {Function | Function[]} callback A callback or callbacks array to register.
    */
   afterProcessMessage(callback) {

--- a/src/modules/hooks/consumer_hooks.js
+++ b/src/modules/hooks/consumer_hooks.js
@@ -28,6 +28,11 @@ class ConsumerHooks extends BaseHooks {
    * - error - The error object in case the processing callback threw.
    * - rejectError - The error object in case a failed rejecting the message after a processing error.
    * - ackError - The error in case failed to 'ack' the message after processing it.
+   * - requeued - True when the message was handed straight back to the broker without the handler
+   *   running at all, because the subscription had already been cancelled - a delivery the broker
+   *   had buffered to us before cancel-ok landed, which happens for up to `prefetch` messages per
+   *   consumer on every shutdown. `content` is absent for these (nothing was deserialized) and no
+   *   "before process" event was emitted, since the processing callback is never invoked.
    * @param {Function | Function[]} callback A callback or callbacks array to register.
    */
   afterProcessMessage(callback) {

--- a/src/modules/producer.js
+++ b/src/modules/producer.js
@@ -218,11 +218,11 @@ class Producer {
     options.persistent = true;
 
     if (options.rpc) {
-      await this.createRpcQueue(queue);
       // generates a correlationId (random uuid) so we know which callback to execute on received response
       options.correlationId = utils.getCorrelationId(options);
-      // reply to us if you receive this message!
-      options.replyTo = await this.amqpRPCQueues[queue].resQueuePromise;
+      // reply to us if you receive this message! Taken from the return value rather than read back
+      // out of `amqpRPCQueues`, which a channel close landing in this very window would have swept.
+      options.replyTo = await this.createRpcQueue(queue);
 
       // deferred promise that will resolve when response is received
       const responsePromise = pDefer();
@@ -233,6 +233,11 @@ class Producer {
       // kills the process. This no-op catch attaches to a derived promise, so the rejection still
       // reaches the caller below unchanged.
       responsePromise.promise.catch(() => {});
+      // `??=` for the same reason: the sweep drops the whole per-queue entry, so a close landing
+      // between the two awaits above leaves nothing to index. Registering the waiter into a fresh
+      // entry keeps the publish below on its normal path - it fails against the dead channel with a
+      // retryable error, so `_sendToQueue` reconnects and republishes rather than losing the request.
+      this.amqpRPCQueues[queue] ??= {};
       this.amqpRPCQueues[queue][options.correlationId] = { responsePromise, timeoutId: null };
 
       try {

--- a/src/modules/producer.js
+++ b/src/modules/producer.js
@@ -131,9 +131,6 @@ class Producer {
       delete rpcQueue.resQueuePromise;
 
       if (error instanceof ConnectionClosedError) {
-        // The connection is terminally closed for the process - stop retrying instead of
-        // spinning forever. This can be reached from the fire-and-forget 'close' listener below,
-        // so we swallow rather than rethrow to avoid an unhandled rejection there.
         logger.warn({
           message: `${loggerAlias} not reinitializing RPC queue for ${sourceQueue}: connection is closed`,
         });
@@ -344,10 +341,6 @@ class Producer {
 
   _shouldRetry(error, currentRetryNumber) {
     if (error instanceof ProducerError || error instanceof ConnectionClosedError || error.message === ERRORS.TIMEOUT) {
-      // ConnectionClosedError means the connection is terminally closed for the process (see
-      // connection.js's close()) - with the default producerMaxRetries: -1 (retry indefinitely),
-      // publish()/produce() would otherwise retry forever against a connection that will never
-      // come back, instead of failing fast the way arnavmq.js's top-level close() documents.
       return false;
     }
     const maxRetries = this._connection.config.producerMaxRetries;

--- a/src/modules/producer.js
+++ b/src/modules/producer.js
@@ -3,6 +3,7 @@ const utils = require('./utils');
 const parsers = require('./message-parsers');
 const { ProducerHooks } = require('./hooks');
 const { logger } = require('./logger');
+const { ConnectionClosedError } = require('./connection');
 
 const ERRORS = {
   TIMEOUT: 'Timeout reached',
@@ -32,6 +33,10 @@ class Producer {
      * [queue: string] -> [correlationId: string] -> {responsePromise, timeoutId}
      */
     this.amqpRPCQueues = {};
+
+    // Set by stop(): does not gate any behavior here (unlike consumer.js's _shuttingDown), it is
+    // just the idempotency flag so a second stop() call is a no-op.
+    this._shuttingDown = false;
   }
 
   set connection(value) {
@@ -124,6 +129,17 @@ class Producer {
       return resQueue;
     } catch (error) {
       delete rpcQueue.resQueuePromise;
+
+      if (error instanceof ConnectionClosedError) {
+        // The connection is terminally closed for the process - stop retrying instead of
+        // spinning forever. This can be reached from the fire-and-forget 'close' listener below,
+        // so we swallow rather than rethrow to avoid an unhandled rejection there.
+        logger.warn({
+          message: `${loggerAlias} not reinitializing RPC queue for ${sourceQueue}: connection is closed`,
+        });
+        return undefined;
+      }
+
       await utils.timeoutPromise(this._connection.config.timeout);
       return await this.createRpcQueue(sourceQueue);
     }
@@ -159,6 +175,36 @@ class Producer {
         delete producer.amqpRPCQueues[queue][corrId];
       }
     }, time);
+  }
+
+  /**
+   * Rejects every RPC promise currently pending in `amqpRPCQueues` (one that has sent its request
+   * and is waiting for a response) with `ConnectionClosedError`, and clears its timeout so no
+   * lingering timer keeps the process alive - without this, a caller awaiting an RPC response
+   * would otherwise hang until `rpcTimeout` (15s default) even though the connection is already
+   * gone. Internal - not part of the object producer.js's factory returns publicly. Idempotent:
+   * a second call is a no-op.
+   * @return {void}
+   */
+  stop() {
+    if (this._shuttingDown) {
+      return;
+    }
+    this._shuttingDown = true;
+
+    Object.values(this.amqpRPCQueues).forEach((rpcQueue) => {
+      Object.keys(rpcQueue).forEach((key) => {
+        // `resQueuePromise` is bookkeeping for the queue itself, not a pending correlationId waiter.
+        if (key === 'resQueuePromise') {
+          return;
+        }
+
+        const waiter = rpcQueue[key];
+        clearTimeout(waiter.timeoutId);
+        waiter.responsePromise.reject(new ConnectionClosedError());
+        delete rpcQueue[key];
+      });
+    });
   }
 
   /**
@@ -297,7 +343,11 @@ class Producer {
   }
 
   _shouldRetry(error, currentRetryNumber) {
-    if (error instanceof ProducerError || error.message === ERRORS.TIMEOUT) {
+    if (error instanceof ProducerError || error instanceof ConnectionClosedError || error.message === ERRORS.TIMEOUT) {
+      // ConnectionClosedError means the connection is terminally closed for the process (see
+      // connection.js's close()) - with the default producerMaxRetries: -1 (retry indefinitely),
+      // publish()/produce() would otherwise retry forever against a connection that will never
+      // come back, instead of failing fast the way arnavmq.js's top-level close() documents.
       return false;
     }
     const maxRetries = this._connection.config.producerMaxRetries;

--- a/src/modules/producer.js
+++ b/src/modules/producer.js
@@ -34,8 +34,9 @@ class Producer {
      */
     this.amqpRPCQueues = {};
 
-    // Set by stop(): does not gate any behavior here (unlike consumer.js's _shuttingDown), it is
-    // just the idempotency flag so a second stop() call is a no-op.
+    // Set by stop(): the idempotency flag so a second stop() call is a no-op, and the gate that
+    // makes any further outgoing RPC *request* fail fast with ConnectionClosedError instead of
+    // registering a waiter nothing will ever answer. Plain (non-RPC) publishes are not gated.
     this._shuttingDown = false;
   }
 
@@ -231,9 +232,25 @@ class Producer {
 
       // deferred promise that will resolve when response is received
       const responsePromise = pDefer();
+      // stop() can reject this deferred while the publish below is still a round-trip in flight -
+      // i.e. before the `await responsePromise.promise` at the end of this function has attached a
+      // handler. A rejection left unhandled across a full turn of the loop trips Node's
+      // unhandled-rejection detection, and under the default `--unhandled-rejections=throw` that
+      // kills the process during the very shutdown that rejected it. This no-op catch attaches to
+      // a derived promise, so the rejection still reaches the caller below unchanged.
+      responsePromise.promise.catch(() => {});
       this.amqpRPCQueues[queue][options.correlationId] = { responsePromise, timeoutId: null };
 
-      await this.publishOrSendToQueue(queue, msg, options);
+      try {
+        await this.publishOrSendToQueue(queue, msg, options);
+      } catch (error) {
+        // The request never made it out, so no response can ever arrive to settle this waiter, and
+        // prepareTimeoutRpc() below was never reached - nothing else will ever clear it. Left in
+        // the registry it lingers until some later stop() rejects it, long after this call's own
+        // handler is gone.
+        delete this.amqpRPCQueues[queue][options.correlationId];
+        throw error;
+      }
 
       // Using given timeout or default one
       const timeout = options.timeout || this._connection.config.rpcTimeout || 0;

--- a/src/modules/producer.js
+++ b/src/modules/producer.js
@@ -222,6 +222,13 @@ class Producer {
       // reply to us if you receive this message!
       options.replyTo = await this.amqpRPCQueues[queue].resQueuePromise;
 
+      // stop() may have run its rejection sweep while createRpcQueue()/resQueuePromise were being
+      // awaited above; registering the waiter after that sweep would leave it pending forever
+      // once publishOrSendToQueue() below starts failing against the closed connection.
+      if (this._shuttingDown) {
+        throw new ConnectionClosedError();
+      }
+
       // deferred promise that will resolve when response is received
       const responsePromise = pDefer();
       this.amqpRPCQueues[queue][options.correlationId] = { responsePromise, timeoutId: null };

--- a/src/modules/producer.js
+++ b/src/modules/producer.js
@@ -34,10 +34,39 @@ class Producer {
      */
     this.amqpRPCQueues = {};
 
-    // Set by stop(): the idempotency flag so a second stop() call is a no-op, and the gate that
-    // makes any further outgoing RPC *request* fail fast with ConnectionClosedError instead of
-    // registering a waiter nothing will ever answer. Plain (non-RPC) publishes are not gated.
-    this._shuttingDown = false;
+    // Bound once so `_initializeRpcQueue` can remove-then-add it and stay at one listener.
+    this._onChannelClose = this._onChannelClose.bind(this);
+  }
+
+  /**
+   * Every pending RPC request has become unanswerable: the reply queue was exclusive to the
+   * connection that just went away, and each request was published carrying that queue's name as
+   * its replyTo, so no answer can ever arrive - not on a reconnect either. Reject the waiters now
+   * so callers fail fast instead of hanging out `rpcTimeout` for an answer that is not coming (and
+   * forever with `rpcTimeout: 0`, which arms no timer at all), and clear their timers so none keeps
+   * the process alive past shutdown. Dropping the whole registry also discards the dead reply-queue
+   * bookkeeping, so the next RPC publish rebuilds it.
+   *
+   * Fires on every teardown path: `Channels.closeAll()` during a graceful `close()`, and amqplib's
+   * `Connection.toClosed()` -> `_closeChannels()` for a channel wedged past closeAll's cap or a
+   * socket that died on its own.
+   * @private
+   */
+  _onChannelClose() {
+    const queues = this.amqpRPCQueues;
+    this.amqpRPCQueues = {};
+
+    Object.values(queues).forEach((rpcQueue) => {
+      Object.entries(rpcQueue).forEach(([key, waiter]) => {
+        // `resQueuePromise` is bookkeeping for the queue itself, not a correlationId waiter.
+        if (key === 'resQueuePromise') {
+          return;
+        }
+
+        clearTimeout(waiter.timeoutId);
+        waiter.responsePromise.reject(new ConnectionClosedError());
+      });
+    });
   }
 
   set connection(value) {
@@ -118,11 +147,10 @@ class Producer {
       const channel = await this._connection.getDefaultChannel();
       await channel.assertQueue(resQueue, { durable: true, exclusive: true });
 
-      // if channel is closed, we want to make sure we cleanup the queue so future calls will recreate it
-      this._connection.addListener('close', () => {
-        delete rpcQueue.resQueuePromise;
-        this.createRpcQueue(sourceQueue);
-      });
+      // Remove-then-add holds this at exactly one listener on the channel no matter how many RPC
+      // queues get initialized on it, and re-arms it on the fresh channel after a reconnect.
+      channel.removeListener('close', this._onChannelClose);
+      channel.addListener('close', this._onChannelClose);
 
       await channel.consume(resQueue, this.maybeAnswer(sourceQueue), {
         noAck: true,
@@ -161,48 +189,21 @@ class Producer {
    */
   prepareTimeoutRpc(queue, corrId, time) {
     const producer = this;
-    let waiter = producer.amqpRPCQueues[queue][corrId];
+    // `?.` because the channel-close sweep drops the whole per-queue entry: a close landing while
+    // the request was still being published leaves nothing here, and the waiter it would have timed
+    // out has already been rejected with ConnectionClosedError.
+    let waiter = producer.amqpRPCQueues[queue]?.[corrId];
     if (!waiter) {
       return;
     }
 
     waiter.timeoutId = setTimeout(() => {
-      waiter = producer.amqpRPCQueues[queue][corrId];
+      waiter = producer.amqpRPCQueues[queue]?.[corrId];
       if (waiter) {
         waiter.responsePromise.reject(new Error(ERRORS.TIMEOUT));
         delete producer.amqpRPCQueues[queue][corrId];
       }
     }, time);
-  }
-
-  /**
-   * Rejects every RPC promise currently pending in `amqpRPCQueues` (one that has sent its request
-   * and is waiting for a response) with `ConnectionClosedError`, and clears its timeout so no
-   * lingering timer keeps the process alive - without this, a caller awaiting an RPC response
-   * would otherwise hang until `rpcTimeout` (15s default) even though the connection is already
-   * gone. Internal - not part of the object producer.js's factory returns publicly. Idempotent:
-   * a second call is a no-op.
-   * @return {void}
-   */
-  stop() {
-    if (this._shuttingDown) {
-      return;
-    }
-    this._shuttingDown = true;
-
-    Object.values(this.amqpRPCQueues).forEach((rpcQueue) => {
-      Object.keys(rpcQueue).forEach((key) => {
-        // `resQueuePromise` is bookkeeping for the queue itself, not a pending correlationId waiter.
-        if (key === 'resQueuePromise') {
-          return;
-        }
-
-        const waiter = rpcQueue[key];
-        clearTimeout(waiter.timeoutId);
-        waiter.responsePromise.reject(new ConnectionClosedError());
-        delete rpcQueue[key];
-      });
-    });
   }
 
   /**
@@ -223,21 +224,14 @@ class Producer {
       // reply to us if you receive this message!
       options.replyTo = await this.amqpRPCQueues[queue].resQueuePromise;
 
-      // stop() may have run its rejection sweep while createRpcQueue()/resQueuePromise were being
-      // awaited above; registering the waiter after that sweep would leave it pending forever
-      // once publishOrSendToQueue() below starts failing against the closed connection.
-      if (this._shuttingDown) {
-        throw new ConnectionClosedError();
-      }
-
       // deferred promise that will resolve when response is received
       const responsePromise = pDefer();
-      // stop() can reject this deferred while the publish below is still a round-trip in flight -
-      // i.e. before the `await responsePromise.promise` at the end of this function has attached a
-      // handler. A rejection left unhandled across a full turn of the loop trips Node's
+      // A channel close can reject this deferred while the publish below is still a round-trip in
+      // flight - i.e. before the `await responsePromise.promise` at the end of this function has
+      // attached a handler. A rejection left unhandled across a full turn of the loop trips Node's
       // unhandled-rejection detection, and under the default `--unhandled-rejections=throw` that
-      // kills the process during the very shutdown that rejected it. This no-op catch attaches to
-      // a derived promise, so the rejection still reaches the caller below unchanged.
+      // kills the process. This no-op catch attaches to a derived promise, so the rejection still
+      // reaches the caller below unchanged.
       responsePromise.promise.catch(() => {});
       this.amqpRPCQueues[queue][options.correlationId] = { responsePromise, timeoutId: null };
 
@@ -246,9 +240,8 @@ class Producer {
       } catch (error) {
         // The request never made it out, so no response can ever arrive to settle this waiter, and
         // prepareTimeoutRpc() below was never reached - nothing else will ever clear it. Left in
-        // the registry it lingers until some later stop() rejects it, long after this call's own
-        // handler is gone.
-        delete this.amqpRPCQueues[queue][options.correlationId];
+        // the registry it leaks until the channel closes.
+        delete this.amqpRPCQueues[queue]?.[options.correlationId];
         throw error;
       }
 

--- a/src/modules/producer.js
+++ b/src/modules/producer.js
@@ -50,12 +50,17 @@ class Producer {
    * Fires on every teardown path: `Channels.closeAll()` during a graceful `close()`, and amqplib's
    * `Connection.toClosed()` -> `_closeChannels()` for a channel wedged past closeAll's cap or a
    * socket that died on its own. The rejection's `origin` tells them apart: 'shutdown' when
-   * `close()` had already flipped `this._connection.isClosed`, 'unexpected' otherwise.
+   * `close()` had already flipped `this._connection.isClosed`, 'unexpected' otherwise. Warn-logs
+   * how many waiters were discarded, so a silent connection drop doesn't disappear pending RPCs
+   * without a trace.
    * @private
    */
   _onChannelClose() {
     const queues = this.amqpRPCQueues;
     this.amqpRPCQueues = {};
+
+    const origin = this._connection.isClosed ? 'shutdown' : 'unexpected';
+    let discardedCount = 0;
 
     Object.values(queues).forEach((rpcQueue) => {
       Object.entries(rpcQueue).forEach(([key, waiter]) => {
@@ -64,12 +69,20 @@ class Producer {
           return;
         }
 
+        discardedCount += 1;
         clearTimeout(waiter.timeoutId);
-        waiter.responsePromise.reject(
-          new ConnectionClosedError(this._connection.isClosed ? 'shutdown' : 'unexpected')
-        );
+        waiter.responsePromise.reject(new ConnectionClosedError(origin));
       });
     });
+
+    if (discardedCount > 0) {
+      logger.warn({
+        message: `${loggerAlias} discarded ${discardedCount} pending RPC ${
+          discardedCount === 1 ? 'request' : 'requests'
+        } on channel close (${origin})`,
+        params: { discardedCount, origin },
+      });
+    }
   }
 
   set connection(value) {

--- a/src/modules/producer.js
+++ b/src/modules/producer.js
@@ -49,7 +49,8 @@ class Producer {
    *
    * Fires on every teardown path: `Channels.closeAll()` during a graceful `close()`, and amqplib's
    * `Connection.toClosed()` -> `_closeChannels()` for a channel wedged past closeAll's cap or a
-   * socket that died on its own.
+   * socket that died on its own. The rejection's `origin` tells them apart: 'shutdown' when
+   * `close()` had already flipped `this._connection.isClosed`, 'unexpected' otherwise.
    * @private
    */
   _onChannelClose() {
@@ -64,7 +65,9 @@ class Producer {
         }
 
         clearTimeout(waiter.timeoutId);
-        waiter.responsePromise.reject(new ConnectionClosedError());
+        waiter.responsePromise.reject(
+          new ConnectionClosedError(this._connection.isClosed ? 'shutdown' : 'unexpected')
+        );
       });
     });
   }

--- a/src/modules/producer.js
+++ b/src/modules/producer.js
@@ -11,6 +11,18 @@ const ERRORS = {
 
 const loggerAlias = 'arnav_mq:producer';
 
+/**
+ * @typedef {Object} RpcWaiter
+ * @property {import('p-defer').DeferredPromise} responsePromise
+ * @property {NodeJS.Timeout|null} timeoutId
+ */
+
+/**
+ * @typedef {Object.<string, RpcWaiter>} RpcQueue Correlation ID -> waiter, plus a
+ *   `resQueuePromise` bookkeeping key for the queue itself (not a waiter).
+ * @property {Promise<string>} [resQueuePromise]
+ */
+
 class ProducerError extends Error {
   constructor({ name, message }) {
     super(message);
@@ -23,18 +35,25 @@ class ProducerError extends Error {
 }
 
 class Producer {
+  /**
+   * @param {import('./connection').Connection} connection
+   */
   constructor(connection) {
+    /** @type {import('./connection').Connection} */
     this._connection = connection;
+    /** @type {ProducerHooks} */
     this.hooks = new ProducerHooks();
 
     /**
      * Map of rpc queues
      *
      * [queue: string] -> [correlationId: string] -> {responsePromise, timeoutId}
+     * @type {Object.<string, RpcQueue>}
      */
     this.amqpRPCQueues = {};
 
     // Bound once so `_initializeRpcQueue` can remove-then-add it and stay at one listener.
+    /** @type {() => void} */
     this._onChannelClose = this._onChannelClose.bind(this);
   }
 

--- a/src/modules/utils.js
+++ b/src/modules/utils.js
@@ -38,7 +38,7 @@ async function withTimeout(promise, timeoutMs, what) {
   try {
     return await Promise.race([promise, timeout]);
   } finally {
-    return clearTimeout(timeoutId);
+    clearTimeout(timeoutId);
   }
 }
 

--- a/src/modules/utils.js
+++ b/src/modules/utils.js
@@ -22,6 +22,26 @@ function getCorrelationId(options) {
   return crypto.randomUUID();
 }
 
+/**
+ * Resolves with `promise`, or rejects once `timeoutMs` elapses - whichever happens first.
+ * @param {Promise} promise
+ * @param {number} timeoutMs
+ * @param {string} what Described in the timeout error message.
+ * @return {Promise}
+ */
+async function withTimeout(promise, timeoutMs, what) {
+  let timeoutId;
+  const timeout = new Promise((_, reject) => {
+    timeoutId = setTimeout(() => reject(new Error(`Timed out after ${timeoutMs}ms waiting for ${what}`)), timeoutMs);
+  });
+
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    return clearTimeout(timeoutId);
+  }
+}
+
 module.exports = {
   /**
    * Default logger to prevent any printing in the terminal
@@ -40,4 +60,6 @@ module.exports = {
     }),
 
   getCorrelationId,
+
+  withTimeout,
 };

--- a/test/docker.js
+++ b/test/docker.js
@@ -20,17 +20,22 @@ class Docker {
   async waitForReady() {
     let lastErr = null;
 
-    for (let i = 0; i < 20; i += 1) {
+    for (let i = 0; i < 40; i += 1) {
+      if (!(await this.isRunning())) {
+        const { stdout } = await exec(`docker logs --tail 50 ${this.name}`).catch(() => ({ stdout: '' }));
+        throw new Error(`RabbitMQ container exited while waiting for it to be ready. Logs:\n${stdout}`);
+      }
+
       try {
         await exec(`docker exec ${this.name} rabbitmqctl status`);
         return;
       } catch (err) {
         lastErr = err;
-        await utils.timeoutPromise(500);
+        await utils.timeoutPromise(1000);
       }
     }
 
-    throw new Error(`RabbitMQ health check failed after 20 iterations: ${lastErr.message}`);
+    throw new Error(`RabbitMQ health check failed after 40 iterations: ${lastErr.message}`);
   }
 
   async isRunning() {

--- a/test/docker.js
+++ b/test/docker.js
@@ -42,7 +42,7 @@ class Docker {
     try {
       const res = await exec(`docker container inspect -f '{{.State.Running}}' ${this.name}`);
       return res.stdout.trim() === 'true';
-    } catch (err) {
+    } catch {
       // We will get an error if container is not runnning.
       return false;
     }

--- a/test/shutdown-spec.js
+++ b/test/shutdown-spec.js
@@ -61,6 +61,16 @@ function deliver(channel, queue, msg) {
   return fn(msg);
 }
 
+/**
+ * basic.cancel by consumerTag for every subscription on `queue` on this consumer - a stand-in for
+ * the removed public per-queue cancel(), for tests that need to cancel a single queue without a
+ * full stop().
+ */
+async function cancelQueue(consumer, queue) {
+  const subscriptions = consumer._subscriptions.filter((sub) => sub.queue === queue);
+  await Promise.all(subscriptions.map((sub) => consumer._cancelSubscription(sub)));
+}
+
 /** A fake amqp.node channel good enough to drive producer.js's RPC path without a broker. */
 function createFakeChannelForRpc() {
   const channel = new EventEmitter();
@@ -85,7 +95,7 @@ describe('graceful shutdown', () => {
         consumer = new Consumer(arnavmq.connection);
       });
 
-      it('cancel() cancels by consumerTag and never closes the shared channel', async () => {
+      it('cancelling a queue cancels by consumerTag and never closes the shared channel', async () => {
         const queue = 'shutdown:cancel:no-close';
         await consumer.consume(queue, () => {});
 
@@ -95,7 +105,7 @@ describe('graceful shutdown', () => {
         const closeSpy = sandbox.spy(channel, 'close');
         const cancelSpy = sandbox.spy(channel, 'cancel');
 
-        await consumer.cancel(queue);
+        await cancelQueue(consumer, queue);
 
         sinon.assert.calledWith(cancelSpy, record.consumerTag);
         sinon.assert.notCalled(closeSpy);
@@ -105,30 +115,30 @@ describe('graceful shutdown', () => {
         await channel.checkQueue(queue);
       });
 
-      // The test above proves cancel() never closes the shared channel via a spy; this proves the
-      // *consequence* end-to-end against the real broker - a live queueB consumer and a live
-      // producer RPC round-trip both keep working concurrently with cancelling queueA, and queueA
-      // itself really stops receiving.
-      it('cancel(queueA) stops A while a concurrent queueB consumer and a producer RPC call keep working (regression: cancel by tag, never close the shared channel)', async () => {
+      // The test above proves cancelling a queue never closes the shared channel via a spy; this
+      // proves the *consequence* end-to-end against the real broker - a live queueB consumer and a
+      // live producer RPC round-trip both keep working concurrently with cancelling queueA, and
+      // queueA itself really stops receiving.
+      it('cancelling queueA stops A while a concurrent queueB consumer and a producer RPC call keep working (regression: cancel by tag, never close the shared channel)', async () => {
         const queueA = 'shutdown:cancel:regression:a';
         const queueB = 'shutdown:cancel:regression:b';
         const rpcQueue = 'shutdown:cancel:regression:rpc';
 
         let countA = 0;
         let countB = 0;
-        await arnavmq.consumer.consume(queueA, () => {
+        await consumer.consume(queueA, () => {
           countA += 1;
         });
-        await arnavmq.consumer.consume(queueB, () => {
+        await consumer.consume(queueB, () => {
           countB += 1;
         });
-        await arnavmq.consumer.consume(rpcQueue, () => 'pong');
+        await consumer.consume(rpcQueue, () => 'pong');
 
         await arnavmq.producer.produce(queueA, { n: 1 });
         await utils.timeoutPromise(300);
         assert.strictEqual(countA, 1, 'expected queueA to receive its message before being cancelled');
 
-        await arnavmq.consumer.cancel(queueA);
+        await cancelQueue(consumer, queueA);
 
         // concurrently with queueA being cancelled: queueB keeps consuming, an RPC round-trip keeps
         // working, and a further produce to the now-cancelled queueA must never be delivered.
@@ -144,7 +154,7 @@ describe('graceful shutdown', () => {
         assert.strictEqual(countA, 1, 'the cancelled queueA subscription must not receive further deliveries');
       });
 
-      it('cancel()/cancelAll() on a record with no consumerTag yet just marks it cancelled', async () => {
+      it('cancelling a record with no consumerTag yet just marks it cancelled', async () => {
         const queue = 'shutdown:cancel:no-tag-yet';
         sandbox.stub(consumer, '_initializeChannel').resolves(null);
 
@@ -156,7 +166,7 @@ describe('graceful shutdown', () => {
         assert(record, 'expected a record to be registered synchronously by subscribe()');
         assert.strictEqual(record.consumerTag, null);
 
-        await consumer.cancel(queue);
+        await cancelQueue(consumer, queue);
 
         assert.strictEqual(record.cancelled, true);
         assert.strictEqual(await subscribePromise, false);
@@ -171,7 +181,7 @@ describe('graceful shutdown', () => {
         const record = [...consumer._subscriptions.values()].find((r) => r.queue === queue);
         assert(record, 'expected a record to be registered synchronously by subscribe()');
 
-        await consumer.cancel(queue);
+        await cancelQueue(consumer, queue);
         assert.strictEqual(await subscribePromise, false);
 
         const callCountAfterCancel = initStub.callCount;
@@ -183,8 +193,8 @@ describe('graceful shutdown', () => {
         );
       });
 
-      it('cancelAll() sets _shuttingDown so even brand-new subscribe() calls never consume', async () => {
-        await consumer.cancelAll();
+      it('_cancelAll() sets _shuttingDown so even brand-new subscribe() calls never consume', async () => {
+        await consumer._cancelAll();
         assert.strictEqual(consumer._shuttingDown, true);
 
         const initSpy = sandbox.spy(consumer, '_initializeChannel');
@@ -236,7 +246,7 @@ describe('graceful shutdown', () => {
 
         for (let i = 0; i < 5; i += 1) {
           await consumer.consume(queue, () => {});
-          await consumer.cancel(queue);
+          await cancelQueue(consumer, queue);
         }
 
         assert.strictEqual(
@@ -250,9 +260,9 @@ describe('graceful shutdown', () => {
     });
 
     // `record.channel` is set inside _initializeChannel, but `record.consumerTag` only exists once
-    // assertQueue+basic.consume have both round-tripped to the broker - a cancel() landing in that
+    // assertQueue+basic.consume have both round-tripped to the broker - a cancel landing in that
     // window must be re-checked once the tag arrives, or the subscription goes live anyway.
-    describe('cancel() landing mid-subscribe (before consumerTag exists)', () => {
+    describe('cancel landing mid-subscribe (before consumerTag exists)', () => {
       it('cancels the subscription on the broker once its tag arrives - two consume()s on one queue, the second cancelled mid-flight', async () => {
         const { channel, consumer } = newTestConsumer();
         const queue = 'shutdown:cancel:mid-flight';
@@ -277,8 +287,8 @@ describe('graceful shutdown', () => {
         assert.strictEqual(second.consumerTag, null, 'expected it to be mid-flight, without a tag yet');
         sinon.assert.called(channel.consume);
 
-        // cancel() here can send nothing to the broker - there is no tag yet.
-        await consumer.cancel(queue);
+        // cancelling here can send nothing to the broker - there is no tag yet.
+        await cancelQueue(consumer, queue);
         assert.strictEqual(second.cancelled, true);
         sinon.assert.neverCalledWith(channel.cancel, 'mid-flight-tag');
 
@@ -313,7 +323,7 @@ describe('graceful shutdown', () => {
         assert(record.channel, 'expected _initializeChannel to have already attached the shared channel');
         assert.strictEqual(record.consumerTag, null);
 
-        await consumer.cancel(queue);
+        await cancelQueue(consumer, queue);
         assertGate.resolve();
 
         assert.strictEqual(
@@ -378,12 +388,12 @@ describe('graceful shutdown', () => {
       });
     });
 
-    describe('drain()', () => {
+    describe('_drain()', () => {
       it('resolves immediately when nothing is in flight', async () => {
         const { consumer } = newTestConsumer();
         await consumer.consume('shutdown:drain:empty', () => 'ok');
 
-        await consumer.drain();
+        await consumer._drain();
       });
 
       it('resolves once the in-flight handler finishes, and cancels nothing', async () => {
@@ -395,7 +405,7 @@ describe('graceful shutdown', () => {
         const deliverPromise = deliver(channel, queue, fakeMessage({ a: 1 }));
 
         assert.strictEqual(consumer.inFlight(queue), 1);
-        const drainPromise = consumer.drain();
+        const drainPromise = consumer._drain();
 
         handlerDefer.resolve('ok');
         await deliverPromise;
@@ -413,12 +423,12 @@ describe('graceful shutdown', () => {
         const deliverPromise = deliver(channel, queue, fakeMessage({ a: 1 }));
 
         let drained = false;
-        consumer.drain().then(() => {
+        consumer._drain().then(() => {
           drained = true;
         });
 
         await utils.timeoutPromise(150);
-        assert.strictEqual(drained, false, 'expected drain() to still be waiting on the in-flight handler');
+        assert.strictEqual(drained, false, 'expected _drain() to still be waiting on the in-flight handler');
 
         handlerDefer.resolve('ok');
         await deliverPromise;
@@ -994,10 +1004,16 @@ describe('graceful shutdown', () => {
         assert.strictEqual(typeof arnavmq.connection.isClosed, 'boolean');
         assert.strictEqual(typeof arnavmq.consumer.consume, 'function');
         assert.strictEqual(typeof arnavmq.consumer.subscribe, 'function');
-        assert.strictEqual(typeof arnavmq.consumer.cancel, 'function');
-        assert.strictEqual(typeof arnavmq.consumer.stop, 'function');
-        assert.strictEqual(typeof arnavmq.consumer.drain, 'function');
         assert.strictEqual(typeof arnavmq.consumer.inFlight, 'function');
+      });
+
+      it('does not expose cancel/stop/drain on the consumer sub-API - close() is the only public shutdown entry point', () => {
+        const arnavmq = arnavmqConfigurator();
+
+        assert.strictEqual(arnavmq.consumer.cancel, undefined);
+        assert.strictEqual(arnavmq.consumer.stop, undefined);
+        assert.strictEqual(arnavmq.consumer.drain, undefined);
+        assert.strictEqual(arnavmq.producer.stop, undefined);
       });
 
       // `instanceof ConnectionClosedError` is how close()'s contract expects callers to detect the
@@ -1112,15 +1128,15 @@ describe('graceful shutdown', () => {
       const queue = 'shutdown:arnavmq-close:idempotent';
       await arnavmq.subscribe(queue, () => {});
 
-      const cancelAllSpy = sandbox.spy(arnavmq.consumer, 'cancelAll');
+      const cancelAllSpy = sandbox.spy(arnavmq.consumer, '_cancelAll');
       const connectionCloseSpy = sandbox.spy(arnavmq.connection, 'close');
 
       await Promise.all([arnavmq.close(), arnavmq.close()]);
       await arnavmq.close();
 
       assert.strictEqual(arnavmq.connection.isClosed, true);
-      // consumer.stop() memoizes its own shutdown promise, so cancelAll() only actually runs once no
-      // matter how many times the top-level close() calls into it.
+      // consumer.stop() memoizes its own shutdown promise, so _cancelAll() only actually runs once
+      // no matter how many times the top-level close() calls into it.
       sinon.assert.calledOnce(cancelAllSpy);
       // the top-level close() itself is called 3 times above and must not throw on any of them.
       sinon.assert.calledThrice(connectionCloseSpy);
@@ -1179,7 +1195,7 @@ describe('graceful shutdown', () => {
       await fresh.close();
     });
 
-    // cancelAll() must mark every record cancelled before the channel's/connection's own 'close'
+    // _cancelAll() must mark every record cancelled before the channel's/connection's own 'close'
     // event fires, or the onChannelClose listener would try to resubscribe against a connection
     // that's being torn down.
     it('after close(), _consumeQueue is never invoked again - no resubscribe fight with the closing connection', async () => {

--- a/test/shutdown-spec.js
+++ b/test/shutdown-spec.js
@@ -1,0 +1,1341 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const EventEmitter = require('events');
+const pDefer = require('p-defer');
+const arnavmqConfigurator = require('../src/index');
+const Consumer = require('../src/modules/consumer');
+const Producer = require('../src/modules/producer');
+const { Connection, ConnectionClosedError } = require('../src/modules/connection');
+const { ArnavMQ } = require('../src/modules/arnavmq');
+const { setLogger } = require('../src/modules/logger');
+const utils = require('../src/modules/utils');
+
+/**
+ * A fake amqp.node channel good enough to drive consumer.js without a broker: it captures the
+ * per-queue consume() callback so tests can deliver fake messages into it directly, and exposes
+ * spies for every broker call consumer.js can make on a channel.
+ */
+function createFakeChannel() {
+  const channel = new EventEmitter();
+  channel.consumeFns = new Map();
+  channel.assertQueue = sinon.stub().resolves({});
+  channel.consume = sinon.stub().callsFake((queue, fn) => {
+    channel.consumeFns.set(queue, fn);
+    return Promise.resolve({ consumerTag: `fake-tag:${queue}:${channel.consumeFns.size}` });
+  });
+  channel.ack = sinon.stub();
+  channel.reject = sinon.stub();
+  channel.cancel = sinon.stub().resolves();
+  channel.close = sinon.stub().resolves();
+  channel.sendToQueue = sinon.stub().returns(true);
+  return channel;
+}
+
+function createFakeConnection(channel, overrides = {}) {
+  return {
+    config: { prefetch: 5, timeout: 10, requeue: true, consumerSuffix: '', ...overrides },
+    getChannel: sinon.stub().resolves(channel),
+    getDefaultChannel: sinon.stub().resolves(channel),
+  };
+}
+
+function fakeMessage(content, properties = {}) {
+  return {
+    content: Buffer.from(JSON.stringify(content)),
+    properties: { contentType: 'application/json', ...properties },
+  };
+}
+
+/** Delivers `msg` into the consumeFunc consumer.js registered for `queue` on this fake channel. */
+function deliver(channel, queue, msg) {
+  const fn = channel.consumeFns.get(queue);
+  assert(fn, `no consume callback captured for queue "${queue}" - was consume() awaited first?`);
+  return fn(msg);
+}
+
+describe('graceful shutdown', () => {
+  describe('subscription registry (consumer.js)', () => {
+    const sandbox = sinon.createSandbox();
+    afterEach(() => sandbox.restore());
+
+    describe('against the real broker', () => {
+      let arnavmq;
+      let consumer;
+
+      beforeEach(() => {
+        arnavmq = arnavmqConfigurator();
+        consumer = new Consumer(arnavmq.connection);
+      });
+
+      it('cancel() cancels by consumerTag and never closes the shared channel', async () => {
+        const queue = 'shutdown:cancel:no-close';
+        await consumer.consume(queue, () => {});
+
+        const record = [...consumer._subscriptions.values()][0];
+        assert(record.consumerTag, 'expected a consumerTag to have been assigned');
+        const { channel } = record;
+        const closeSpy = sandbox.spy(channel, 'close');
+        const cancelSpy = sandbox.spy(channel, 'cancel');
+
+        await consumer.cancel(queue);
+
+        sinon.assert.calledWith(cancelSpy, record.consumerTag);
+        sinon.assert.notCalled(closeSpy);
+        assert.strictEqual(record.cancelled, true);
+
+        // the channel is shared and must still be usable by everyone else afterward
+        await channel.checkQueue(queue);
+      });
+
+      // The test above proves cancel() never closes the shared channel via a spy; this proves the
+      // *consequence* end-to-end against the real broker - a live queueB consumer and a live
+      // producer RPC round-trip both keep working concurrently with cancelling queueA, and queueA
+      // itself really stops receiving.
+      it('cancel(queueA) stops A while a concurrent queueB consumer and a producer RPC call keep working (regression: cancel by tag, never close the shared channel)', async () => {
+        const queueA = 'shutdown:cancel:regression:a';
+        const queueB = 'shutdown:cancel:regression:b';
+        const rpcQueue = 'shutdown:cancel:regression:rpc';
+
+        let countA = 0;
+        let countB = 0;
+        await arnavmq.consumer.consume(queueA, () => {
+          countA += 1;
+        });
+        await arnavmq.consumer.consume(queueB, () => {
+          countB += 1;
+        });
+        await arnavmq.consumer.consume(rpcQueue, () => 'pong');
+
+        await arnavmq.producer.produce(queueA, { n: 1 });
+        await utils.timeoutPromise(300);
+        assert.strictEqual(countA, 1, 'expected queueA to receive its message before being cancelled');
+
+        await arnavmq.consumer.cancel(queueA);
+
+        // concurrently with queueA being cancelled: queueB keeps consuming, an RPC round-trip keeps
+        // working, and a further produce to the now-cancelled queueA must never be delivered.
+        const [rpcResult] = await Promise.all([
+          arnavmq.producer.produce(rpcQueue, { ping: true }, { rpc: true }),
+          arnavmq.producer.produce(queueB, { n: 1 }),
+          arnavmq.producer.produce(queueA, { n: 2 }),
+        ]);
+        await utils.timeoutPromise(300);
+
+        assert.strictEqual(rpcResult, 'pong', 'expected the RPC round-trip to keep working after cancelling queueA');
+        assert.strictEqual(countB, 1, 'expected queueB to keep receiving messages after cancelling queueA');
+        assert.strictEqual(countA, 1, 'the cancelled queueA subscription must not receive further deliveries');
+      });
+
+      it('cancel()/cancelAll() on a record with no consumerTag yet just marks it cancelled', async () => {
+        const queue = 'shutdown:cancel:no-tag-yet';
+        sandbox.stub(consumer, '_initializeChannel').resolves(null);
+
+        // subscribe() synchronously creates+registers the record before its first internal await,
+        // so it is visible on the registry immediately even though the returned promise is still
+        // pending (stuck in the retry loop because _initializeChannel always resolves null here).
+        const subscribePromise = consumer.subscribe(queue, () => {});
+        const record = [...consumer._subscriptions.values()].find((r) => r.queue === queue);
+        assert(record, 'expected a record to be registered synchronously by subscribe()');
+        assert.strictEqual(record.consumerTag, null);
+
+        await consumer.cancel(queue);
+
+        assert.strictEqual(record.cancelled, true);
+        assert.strictEqual(await subscribePromise, false);
+      });
+
+      it('stops the retry loop once cancelled, without ever consuming', async () => {
+        const queue = 'shutdown:retry:stop-on-cancel';
+        arnavmqConfigurator({ timeout: 20 });
+        const initStub = sandbox.stub(consumer, '_initializeChannel').resolves(null);
+
+        const subscribePromise = consumer.subscribe(queue, () => {});
+        const record = [...consumer._subscriptions.values()].find((r) => r.queue === queue);
+        assert(record, 'expected a record to be registered synchronously by subscribe()');
+
+        await consumer.cancel(queue);
+        assert.strictEqual(await subscribePromise, false);
+
+        const callCountAfterCancel = initStub.callCount;
+        await utils.timeoutPromise(100);
+        assert.strictEqual(
+          initStub.callCount,
+          callCountAfterCancel,
+          'the retry loop kept calling _initializeChannel after the subscription was cancelled',
+        );
+      });
+
+      it('cancelAll() sets _shuttingDown so even brand-new subscribe() calls never consume', async () => {
+        await consumer.cancelAll();
+        assert.strictEqual(consumer._shuttingDown, true);
+
+        const initSpy = sandbox.spy(consumer, '_initializeChannel');
+        const result = await consumer.subscribe('shutdown:after-cancel-all', () => {});
+
+        assert.strictEqual(result, false);
+        sinon.assert.notCalled(initSpy);
+      });
+    });
+
+    describe('listener hygiene on the shared channel', () => {
+      it('does not accumulate close listeners across repeated _initializeChannel calls for one record', async () => {
+        const sharedChannel = createFakeChannel();
+        const connection = createFakeConnection(sharedChannel);
+        const consumer = new Consumer(connection);
+        const record = {
+          id: 1,
+          queue: 'shared-channel-queue',
+          options: { channel: {} },
+          callback: () => {},
+          channel: null,
+          consumerTag: null,
+          onChannelClose: null,
+          cancelled: false,
+          inFlightMessages: new Set(),
+          abandonedMessages: new Set(),
+        };
+
+        await consumer._initializeChannel(record);
+        await consumer._initializeChannel(record);
+        await consumer._initializeChannel(record);
+
+        assert.strictEqual(sharedChannel.listenerCount('close'), 1);
+      });
+
+      it('the resubscribe-on-close listener is a no-op once shutting down / cancelled', async () => {
+        const sharedChannel = createFakeChannel();
+        const connection = createFakeConnection(sharedChannel);
+        const consumer = new Consumer(connection);
+
+        await consumer.consume('shutdown:onclose:guard', () => {});
+        const record = [...consumer._subscriptions.values()][0];
+        const subscribeSpy = sinon.spy(consumer, '_subscribe');
+
+        record.cancelled = true;
+        sharedChannel.emit('close');
+
+        sinon.assert.notCalled(subscribeSpy);
+      });
+
+      it('_cancelSubscription removes the record close listener, so repeated subscribe->cancel cycles do not leak listeners', async () => {
+        const sharedChannel = createFakeChannel();
+        const connection = createFakeConnection(sharedChannel);
+        const consumer = new Consumer(connection);
+        const queue = 'shutdown:cancel:listener-hygiene';
+
+        for (let i = 0; i < 5; i += 1) {
+          await consumer.consume(queue, () => {});
+          await consumer.cancel(queue);
+        }
+
+        assert.strictEqual(
+          sharedChannel.listenerCount('close'),
+          0,
+          'cancelled subscriptions must not leave their resubscribe listener on the shared channel',
+        );
+        // ...but the records themselves stay: _abandonInFlightMessages()/inFlight() still read them.
+        assert.strictEqual(consumer._subscriptions.length, 5, 'cancelled records must remain in the registry');
+      });
+    });
+
+    // `record.channel` is set inside _initializeChannel, but `record.consumerTag` only exists once
+    // assertQueue+basic.consume have both round-tripped to the broker - a cancel() landing in that
+    // window must be re-checked once the tag arrives, or the subscription goes live anyway.
+    describe('cancel() landing mid-subscribe (before consumerTag exists)', () => {
+      it('cancels the subscription on the broker once its tag arrives - two consume()s on one queue, the second cancelled mid-flight', async () => {
+        const channel = createFakeChannel();
+        const connection = createFakeConnection(channel);
+        const consumer = new Consumer(connection);
+        const queue = 'shutdown:cancel:mid-flight';
+
+        // First subscription on the queue goes live normally.
+        await consumer.consume(queue, () => {});
+        const [first] = [...consumer._subscriptions.values()];
+        assert(first.consumerTag, 'expected the first subscription to be fully subscribed');
+
+        // The second one is held inside channel.consume() - i.e. past _initializeChannel (so
+        // record.channel is set) but before record.consumerTag exists.
+        const consumeGate = pDefer();
+        channel.consume = sinon.stub().callsFake(async (q, fn) => {
+          await consumeGate.promise;
+          channel.consumeFns.set(q, fn);
+          return { consumerTag: 'mid-flight-tag' };
+        });
+
+        const subscribePromise = consumer.consume(queue, () => {});
+        await utils.timeoutPromise(20); // let it reach the gated channel.consume()
+        const second = [...consumer._subscriptions.values()][1];
+        assert(second, 'expected the second subscription to be registered');
+        assert.strictEqual(second.consumerTag, null, 'expected it to be mid-flight, without a tag yet');
+        sinon.assert.called(channel.consume);
+
+        // cancel() here can send nothing to the broker - there is no tag yet.
+        await consumer.cancel(queue);
+        assert.strictEqual(second.cancelled, true);
+        sinon.assert.neverCalledWith(channel.cancel, 'mid-flight-tag');
+
+        // Now the broker answers the basic.consume. The tag exists, so the cancellation must be
+        // carried out for real rather than silently dropped.
+        consumeGate.resolve();
+        assert.strictEqual(
+          await subscribePromise,
+          false,
+          'a subscription cancelled mid-flight must not report success',
+        );
+
+        assert.strictEqual(second.consumerTag, 'mid-flight-tag');
+        sinon.assert.calledWith(channel.cancel, 'mid-flight-tag');
+        sinon.assert.calledWith(channel.cancel, first.consumerTag);
+        sinon.assert.notCalled(channel.close);
+      });
+
+      it('skips the basic.consume round-trip entirely when the cancel lands before it (mid-assertQueue)', async () => {
+        const channel = createFakeChannel();
+        const connection = createFakeConnection(channel);
+        const consumer = new Consumer(connection);
+        const queue = 'shutdown:cancel:mid-assert-queue';
+
+        const assertGate = pDefer();
+        channel.assertQueue = sinon.stub().callsFake(async () => {
+          await assertGate.promise;
+          return {};
+        });
+
+        const subscribePromise = consumer.subscribe(queue, () => {});
+        await utils.timeoutPromise(20); // let it reach the gated assertQueue()
+        const record = [...consumer._subscriptions.values()][0];
+        assert(record.channel, 'expected _initializeChannel to have already attached the shared channel');
+        assert.strictEqual(record.consumerTag, null);
+
+        await consumer.cancel(queue);
+        assertGate.resolve();
+
+        assert.strictEqual(
+          await subscribePromise,
+          false,
+          'a subscription cancelled mid-flight must not report success',
+        );
+        sinon.assert.notCalled(channel.consume);
+        assert.strictEqual(record.consumerTag, null);
+      });
+    });
+
+    describe('in-flight tracking', () => {
+      it('brackets both the ack path and the reject path', async () => {
+        const channel = createFakeChannel();
+        const connection = createFakeConnection(channel);
+        const consumer = new Consumer(connection);
+
+        const ackQueue = 'shutdown:inflight:ack-path';
+        let observedDuringAckHandler = null;
+        await consumer.consume(ackQueue, () => {
+          observedDuringAckHandler = consumer.inFlight(ackQueue);
+          return 'ok';
+        });
+
+        assert.strictEqual(consumer.inFlight(ackQueue), 0);
+        await deliver(channel, ackQueue, fakeMessage({ a: 1 }));
+        assert.strictEqual(observedDuringAckHandler, 1, 'expected inFlight() to be 1 while the handler runs');
+        assert.strictEqual(consumer.inFlight(ackQueue), 0, 'expected inFlight() back to 0 once acked');
+        sinon.assert.calledOnce(channel.ack);
+
+        const rejectQueue = 'shutdown:inflight:reject-path';
+        let observedDuringRejectHandler = null;
+        await consumer.consume(rejectQueue, () => {
+          observedDuringRejectHandler = consumer.inFlight(rejectQueue);
+          throw new Error('boom');
+        });
+
+        await deliver(channel, rejectQueue, fakeMessage({ a: 1 }));
+        assert.strictEqual(observedDuringRejectHandler, 1, 'expected inFlight() to be 1 while the handler runs');
+        assert.strictEqual(consumer.inFlight(rejectQueue), 0, 'expected inFlight() back to 0 once rejected');
+        sinon.assert.calledOnce(channel.reject);
+      });
+    });
+
+    describe('abandoned-message guards (drain-timeout path)', () => {
+      it('skips ack for an abandoned message and leaves the channel undamaged', async () => {
+        const channel = createFakeChannel();
+        const connection = createFakeConnection(channel);
+        const consumer = new Consumer(connection);
+        const queue = 'shutdown:guard:ack';
+
+        await consumer.consume(queue, () => 'ok');
+        const record = [...consumer._subscriptions.values()][0];
+        const msg = fakeMessage({ a: 1 });
+        record.abandonedMessages.add(msg);
+
+        await deliver(channel, queue, msg);
+
+        sinon.assert.notCalled(channel.ack);
+        sinon.assert.notCalled(channel.close);
+      });
+
+      it('skips reject for an abandoned message on the handler-error path and leaves the channel undamaged', async () => {
+        const channel = createFakeChannel();
+        const connection = createFakeConnection(channel);
+        const consumer = new Consumer(connection);
+        const queue = 'shutdown:guard:reject';
+
+        await consumer.consume(queue, () => {
+          throw new Error('boom');
+        });
+        const record = [...consumer._subscriptions.values()][0];
+        const msg = fakeMessage({ a: 1 });
+        record.abandonedMessages.add(msg);
+
+        await deliver(channel, queue, msg);
+
+        sinon.assert.notCalled(channel.reject);
+        sinon.assert.notCalled(channel.close);
+      });
+
+      it('skips the RPC reply for an abandoned message on the success path', async () => {
+        const channel = createFakeChannel();
+        const connection = createFakeConnection(channel);
+        const consumer = new Consumer(connection);
+        const queue = 'shutdown:guard:rpc-success';
+
+        await consumer.consume(queue, () => 'ok');
+        const record = [...consumer._subscriptions.values()][0];
+        const msg = fakeMessage({ a: 1 }, { replyTo: 'reply-queue', correlationId: 'abc' });
+        record.abandonedMessages.add(msg);
+
+        await deliver(channel, queue, msg);
+
+        sinon.assert.notCalled(channel.sendToQueue);
+        sinon.assert.notCalled(channel.close);
+      });
+
+      it('skips the RPC reply for an abandoned message on the non-requeue reject path', async () => {
+        const channel = createFakeChannel();
+        const connection = createFakeConnection(channel, { requeue: false });
+        const consumer = new Consumer(connection);
+        const queue = 'shutdown:guard:rpc-reject';
+
+        await consumer.consume(queue, () => {
+          throw new Error('boom');
+        });
+        const record = [...consumer._subscriptions.values()][0];
+        const msg = fakeMessage({ a: 1 }, { replyTo: 'reply-queue', correlationId: 'abc' });
+        record.abandonedMessages.add(msg);
+
+        await deliver(channel, queue, msg);
+
+        sinon.assert.notCalled(channel.reject);
+        sinon.assert.notCalled(channel.sendToQueue);
+        sinon.assert.notCalled(channel.close);
+      });
+    });
+
+    describe('drain()', () => {
+      it('resolves true immediately when nothing is in flight', async () => {
+        const channel = createFakeChannel();
+        const connection = createFakeConnection(channel);
+        const consumer = new Consumer(connection);
+        await consumer.consume('shutdown:drain:empty', () => 'ok');
+
+        assert.strictEqual(await consumer.drain(1000), true);
+      });
+
+      it('resolves true once the in-flight handler finishes, and cancels nothing', async () => {
+        const channel = createFakeChannel();
+        const connection = createFakeConnection(channel);
+        const consumer = new Consumer(connection);
+        const queue = 'shutdown:drain:waits-then-true';
+        const handlerDefer = pDefer();
+
+        await consumer.consume(queue, () => handlerDefer.promise);
+        const deliverPromise = deliver(channel, queue, fakeMessage({ a: 1 }));
+
+        assert.strictEqual(consumer.inFlight(queue), 1);
+        const drainPromise = consumer.drain(1000);
+
+        handlerDefer.resolve('ok');
+        await deliverPromise;
+
+        assert.strictEqual(await drainPromise, true);
+        sinon.assert.notCalled(channel.cancel);
+      });
+
+      it('resolves false when the in-flight handler does not finish before the timeout', async () => {
+        const channel = createFakeChannel();
+        const connection = createFakeConnection(channel);
+        const consumer = new Consumer(connection);
+        const queue = 'shutdown:drain:times-out';
+        const handlerDefer = pDefer();
+
+        await consumer.consume(queue, () => handlerDefer.promise);
+        const deliverPromise = deliver(channel, queue, fakeMessage({ a: 1 }));
+
+        assert.strictEqual(await consumer.drain(120), false);
+
+        // let the still-running handler finish so it doesn't leak into the next test
+        handlerDefer.resolve('ok');
+        await deliverPromise;
+      });
+    });
+
+    describe('stop()', () => {
+      it('cancels every subscription then reports a clean drain with nothing abandoned', async () => {
+        const channel = createFakeChannel();
+        const connection = createFakeConnection(channel);
+        const consumer = new Consumer(connection);
+        const queue = 'shutdown:stop:clean';
+
+        await consumer.consume(queue, () => 'ok');
+
+        assert.deepStrictEqual(await consumer.stop({ timeout: 1000 }), { drained: true, abandoned: {} });
+        sinon.assert.called(channel.cancel);
+        sinon.assert.notCalled(channel.close);
+        assert.strictEqual(consumer._shuttingDown, true);
+      });
+
+      it('is idempotent - concurrent calls share one in-flight shutdown', async () => {
+        const channel = createFakeChannel();
+        const connection = createFakeConnection(channel);
+        const consumer = new Consumer(connection);
+        await consumer.consume('shutdown:stop:idempotent', () => 'ok');
+
+        const [first, second] = await Promise.all([consumer.stop(), consumer.stop()]);
+
+        assert.deepStrictEqual(first, { drained: true, abandoned: {} });
+        assert.strictEqual(second, first, 'both calls must resolve with the one memoized shutdown result');
+        sinon.assert.calledOnce(channel.cancel);
+      });
+
+      it("on timeout, rejects+requeues abandoned in-flight messages and guards the handler's own ack afterward", async () => {
+        const channel = createFakeChannel();
+        const connection = createFakeConnection(channel);
+        const consumer = new Consumer(connection);
+        const queue = 'shutdown:stop:timeout-abandons';
+        const handlerDefer = pDefer();
+
+        await consumer.consume(queue, () => handlerDefer.promise);
+        const deliverPromise = deliver(channel, queue, fakeMessage({ a: 1 }));
+
+        const stopped = await consumer.stop({ timeout: 120 });
+        assert.deepStrictEqual(stopped, { drained: false, abandoned: { [queue]: 1 } });
+
+        sinon.assert.calledOnce(channel.reject);
+        sinon.assert.calledWith(channel.reject, sinon.match.any, true);
+        sinon.assert.notCalled(channel.close);
+
+        // the handler is not killed - it keeps running and eventually resolves; its own completion
+        // must not double-ack/double-reject/double-reply on a delivery already abandoned above.
+        handlerDefer.resolve('ok');
+        await deliverPromise;
+
+        sinon.assert.notCalled(channel.ack);
+        sinon.assert.calledOnce(channel.reject);
+        sinon.assert.notCalled(channel.close);
+      });
+
+      // The per-queue abandoned count is returned to the caller, who turns it into a metric - it has
+      // to be accurate and scoped per queue rather than aggregated.
+      it('reports the abandoned-message count per queue - only the queue that timed out appears in the map', async () => {
+        const channel = createFakeChannel();
+        const connection = createFakeConnection(channel);
+        const consumer = new Consumer(connection);
+        const cleanQueue = 'shutdown:stop:abandoned-map:clean';
+        const stuckQueue = 'shutdown:stop:abandoned-map:stuck';
+        const handlerDefer = pDefer();
+
+        await consumer.consume(cleanQueue, () => 'ok');
+        await consumer.consume(stuckQueue, () => handlerDefer.promise);
+
+        // one message drains cleanly on cleanQueue before stop() is even called...
+        await deliver(channel, cleanQueue, fakeMessage({ a: 1 }));
+        // ...while two are stuck in the never-resolving handler on stuckQueue.
+        const stuckDeliveries = [
+          deliver(channel, stuckQueue, fakeMessage({ b: 1 })),
+          deliver(channel, stuckQueue, fakeMessage({ b: 2 })),
+        ];
+        assert.strictEqual(consumer.inFlight(stuckQueue), 2);
+
+        const result = await consumer.stop({ timeout: 120 });
+
+        assert.deepStrictEqual(result, { drained: false, abandoned: { [stuckQueue]: 2 } });
+        assert.strictEqual(channel.reject.callCount, 2, 'expected exactly the two stuck messages to be requeued');
+
+        // let the still-running handler finish so it doesn't leak into the next test
+        handlerDefer.resolve('ok');
+        await Promise.all(stuckDeliveries);
+      });
+    });
+
+    describe('inFlight()', () => {
+      it('counts across all queues', async () => {
+        const channel = createFakeChannel();
+        const connection = createFakeConnection(channel);
+        const consumer = new Consumer(connection);
+        const queueA = 'shutdown:inflight:scope-a';
+        const queueB = 'shutdown:inflight:scope-b';
+        const deferA = pDefer();
+        const deferB = pDefer();
+
+        await consumer.consume(queueA, () => deferA.promise);
+        await consumer.consume(queueB, () => deferB.promise);
+
+        const deliverA = deliver(channel, queueA, fakeMessage({ a: 1 }));
+        const deliverB = deliver(channel, queueB, fakeMessage({ b: 1 }));
+
+        assert.strictEqual(consumer.inFlight(), 2);
+
+        deferA.resolve('ok');
+        deferB.resolve('ok');
+        await Promise.all([deliverA, deliverB]);
+
+        assert.strictEqual(consumer.inFlight(), 0);
+      });
+    });
+  });
+
+  // These tests construct their own `Connection` instances (via the exported `Connection` class,
+  // not the module's singleton factory) so they can freely call `close()` against a real broker
+  // connection without tearing down the shared singleton every other spec file in this suite relies
+  // on.
+  describe('connection.js', () => {
+    const sandbox = sinon.createSandbox();
+    afterEach(() => sandbox.restore());
+
+    function newConnection(overrides = {}) {
+      return new Connection({
+        host: 'amqp://localhost',
+        hostname: 'shutdown-connection-test',
+        timeout: 10,
+        ...overrides,
+      });
+    }
+
+    describe('isClosed', () => {
+      it('is false before close() and true as soon as close() is invoked (before it even resolves)', () => {
+        const conn = newConnection();
+        assert.strictEqual(conn.isClosed, false);
+
+        const closePromise = conn.close();
+        assert.strictEqual(
+          conn.isClosed,
+          true,
+          'expected _closed to flip synchronously, before any await inside close()',
+        );
+
+        return closePromise;
+      });
+    });
+
+    describe('close()', () => {
+      it('resolves cleanly when no connection was ever established', async () => {
+        const conn = newConnection();
+        await conn.close();
+        assert.strictEqual(conn.isClosed, true);
+      });
+
+      it('closes the underlying amqp connection exactly once on sequential double-close', async () => {
+        const conn = newConnection();
+        const amqpConnection = await conn.getConnection();
+        const closeSpy = sandbox.spy(amqpConnection, 'close');
+
+        await conn.close();
+        await conn.close();
+
+        sinon.assert.calledOnce(closeSpy);
+        assert.strictEqual(conn.isClosed, true);
+      });
+
+      it('is idempotent under concurrent double-close - both calls share one close, no unhandled rejection', async () => {
+        const conn = newConnection();
+        const amqpConnection = await conn.getConnection();
+        const closeSpy = sandbox.spy(amqpConnection, 'close');
+
+        const [first, second] = await Promise.all([conn.close(), conn.close()]);
+
+        assert.strictEqual(first, undefined);
+        assert.strictEqual(second, undefined);
+        sinon.assert.calledOnce(closeSpy);
+        assert.strictEqual(conn.isClosed, true);
+      });
+
+      it("doesn't race an in-flight connect - awaits it, lets it resolve, then closes that connection", async () => {
+        const conn = newConnection();
+
+        const connectPromise = conn.getConnection(); // connect kicked off, not yet resolved
+        const closePromise = conn.close(); // close() must not tear down the in-flight connect
+
+        const amqpConnection = await connectPromise;
+        assert(amqpConnection, 'expected the in-flight connect to still resolve with a connection');
+
+        await closePromise;
+
+        assert.strictEqual(conn.isClosed, true);
+      });
+
+      it('logs and swallows an in-flight connect that fails while close() is waiting on it', async () => {
+        const fakeLogger = { debug: sinon.stub(), info: sinon.stub(), warn: sinon.stub(), error: sinon.stub() };
+        setLogger(fakeLogger);
+        try {
+          // nothing is listening on 5673, so this connect fails on its own while close() awaits it
+          const conn = newConnection({ host: 'amqp://localhost:5673' });
+          const connectPromise = conn.getConnection();
+          const closePromise = conn.close();
+
+          await Promise.all([assert.rejects(() => connectPromise), closePromise]); // close() must not reject
+
+          assert.strictEqual(conn.isClosed, true);
+          sinon.assert.calledWithMatch(fakeLogger.debug, {
+            message: sinon.match(/in-flight connection attempt while closing/),
+          });
+        } finally {
+          setLogger(utils.emptyLogger);
+        }
+      });
+
+      it('swallows errors from closing an already-broken socket instead of rejecting', async () => {
+        const conn = newConnection();
+        const amqpConnection = await conn.getConnection();
+        sandbox.stub(amqpConnection, 'close').rejects(new Error('socket already gone'));
+
+        await conn.close(); // must not throw
+        assert.strictEqual(conn.isClosed, true);
+      });
+
+      // `channel.ack()`/`channel.reject()` are fire-and-forget in AMQP 0-9-1, so dropping the socket
+      // straight away can lose them to the broker's requeue-on-disconnect cleanup. `Channel.Close`
+      // round-trips, so closing every channel first is the barrier that guarantees the broker
+      // processed them.
+      it('gracefully closes every cached channel before closing the socket', async () => {
+        const conn = newConnection({ prefetch: 5 });
+        const amqpConnection = await conn.getConnection();
+        const defaultChannel = await conn.getDefaultChannel();
+        const customChannel = await conn.getChannel('shutdown:connection:custom-prefetch', { prefetch: 2 });
+        assert.notStrictEqual(defaultChannel, customChannel, 'expected the custom prefetch to get its own channel');
+
+        const defaultCloseSpy = sandbox.spy(defaultChannel, 'close');
+        const customCloseSpy = sandbox.spy(customChannel, 'close');
+        const connectionCloseSpy = sandbox.spy(amqpConnection, 'close');
+
+        await conn.close();
+
+        sinon.assert.calledOnce(defaultCloseSpy);
+        sinon.assert.calledOnce(customCloseSpy);
+        sinon.assert.callOrder(defaultCloseSpy, connectionCloseSpy);
+        sinon.assert.callOrder(customCloseSpy, connectionCloseSpy);
+      });
+
+      it('closes the remaining channels and the socket even when one channel fails to close', async () => {
+        const conn = newConnection({ prefetch: 5 });
+        const amqpConnection = await conn.getConnection();
+        const goodChannel = await conn.getDefaultChannel();
+        const badChannel = await conn.getChannel('shutdown:connection:bad-channel', { prefetch: 2 });
+
+        const goodCloseSpy = sandbox.spy(goodChannel, 'close');
+        sandbox.stub(badChannel, 'close').rejects(new Error('channel already gone'));
+        const connectionCloseSpy = sandbox.spy(amqpConnection, 'close');
+
+        await conn.close(); // must not throw
+
+        sinon.assert.calledOnce(goodCloseSpy);
+        sinon.assert.calledOnce(connectionCloseSpy);
+        assert.strictEqual(conn.isClosed, true);
+      });
+
+      it('gives up on a channel that never confirms its close rather than hanging shutdown forever', async () => {
+        const conn = newConnection({ prefetch: 5 });
+        const amqpConnection = await conn.getConnection();
+        const channel = await conn.getDefaultChannel();
+        const connectionCloseSpy = sandbox.spy(amqpConnection, 'close');
+        // amqplib leaves `channel.close()` pending forever if the Channel.Close-Ok never arrives (the
+        // socket dying mid-handshake does not settle it, nor does a simultaneous server-side close).
+        // The barrier is best-effort: it must be capped, or a wedged broker means a pod that never exits.
+        sandbox.stub(channel, 'close').returns(new Promise(() => {}));
+
+        const start = Date.now();
+        await conn.close();
+        const elapsed = Date.now() - start;
+
+        sinon.assert.calledOnce(connectionCloseSpy);
+        assert.strictEqual(conn.isClosed, true);
+        assert(elapsed >= 4000, `expected close() to actually wait out the channel-close cap, took only ${elapsed}ms`);
+        assert(elapsed < 15000, `expected close() to give up on the wedged channel, took ${elapsed}ms`);
+      });
+
+      it('gives up on a channel whose creation never finishes rather than hanging shutdown forever', async () => {
+        const conn = newConnection({ prefetch: 5 });
+        const amqpConnection = await conn.getConnection();
+        const connectionCloseSpy = sandbox.spy(amqpConnection, 'close');
+
+        // A cache entry still pending when shutdown starts - a channel allocated moments earlier whose
+        // Channel.Open-Ok/Basic.Qos-Ok never arrived from a broker that stopped answering while its TCP
+        // connection stayed up. The cap has to cover awaiting the entry itself, not just close().
+        // eslint-disable-next-line no-underscore-dangle
+        conn._channels._channels.set('never-opens', { chann: new Promise(() => {}), config: { prefetch: 5 } });
+
+        const start = Date.now();
+        await conn.close();
+        const elapsed = Date.now() - start;
+
+        sinon.assert.calledOnce(connectionCloseSpy);
+        assert.strictEqual(conn.isClosed, true);
+        assert(elapsed >= 4000, `expected close() to actually wait out the cap, took only ${elapsed}ms`);
+        assert(elapsed < 15000, `expected close() to give up on the never-opened channel, took ${elapsed}ms`);
+      });
+    });
+
+    describe('channel listener registration', () => {
+      it("attaches the channel's error/close listeners before awaiting prefetch", async () => {
+        const conn = newConnection({ prefetch: 5 });
+        const amqpConnection = await conn.getConnection();
+
+        const fakeChannel = new EventEmitter();
+        const prefetchGate = pDefer();
+        fakeChannel.prefetch = sinon.stub().returns(prefetchGate.promise);
+        fakeChannel.close = sinon.stub().resolves();
+        sandbox.stub(amqpConnection, 'createChannel').resolves(fakeChannel);
+
+        const channelPromise = conn.getDefaultChannel();
+        // wait until we are inside the prefetch round-trip, with the channel allocated but qos pending
+        for (let i = 0; i < 100 && !fakeChannel.prefetch.called; i += 1) {
+          await utils.timeoutPromise(10);
+        }
+        sinon.assert.calledOnce(fakeChannel.prefetch);
+
+        assert.strictEqual(fakeChannel.listenerCount('error'), 1, "expected the 'error' listener on before prefetch");
+        assert.strictEqual(fakeChannel.listenerCount('close'), 1, "expected the 'close' listener on before prefetch");
+        // The actual hazard: amqplib routes a server-sent Channel.Close through safeEmit(ch,'error'),
+        // which rethrows when nothing is listening - out of its frame handler, into an uncaught
+        // exception that kills the process. With the listener already on, this emit is absorbed.
+        assert.doesNotThrow(() => fakeChannel.emit('error', new Error('Channel closed by server: simulated')));
+
+        prefetchGate.resolve();
+        assert.strictEqual(await channelPromise, fakeChannel);
+
+        await conn.close();
+      });
+    });
+
+    describe('getConnection() after close()', () => {
+      it('rejects with ConnectionClosedError, and does not attempt to reconnect', async () => {
+        const conn = newConnection();
+        await conn.getConnection();
+        await conn.close();
+
+        await assert.rejects(
+          () => conn.getConnection(),
+          (err) => {
+            assert(err instanceof ConnectionClosedError, `expected ConnectionClosedError, got ${err.constructor.name}`);
+            return true;
+          },
+        );
+      });
+
+      it('also rejects for a connection that was never connected before close()', async () => {
+        const conn = newConnection();
+        await conn.close();
+
+        await assert.rejects(() => conn.getConnection(), ConnectionClosedError);
+      });
+
+      it('getChannel()/getDefaultChannel() built on getConnection() also reject with ConnectionClosedError', async () => {
+        const conn = newConnection();
+        await conn.getConnection();
+        await conn.close();
+
+        await assert.rejects(() => conn.getDefaultChannel(), ConnectionClosedError);
+        await assert.rejects(() => conn.getChannel('any-queue', {}), ConnectionClosedError);
+      });
+    });
+  });
+
+  describe('producer.js reconnect-on-close guard', () => {
+    const sandbox = sinon.createSandbox();
+    afterEach(() => sandbox.restore());
+
+    function createFakeChannelForRpc() {
+      const channel = new EventEmitter();
+      channel.assertQueue = sinon.stub().resolves({});
+      channel.consume = sinon.stub().resolves({ consumerTag: 'fake-tag' });
+      return channel;
+    }
+
+    /** A fake connection whose 'close' listeners are driven by a real EventEmitter, like the amqp one. */
+    function createFakeConnectionWithCloseEvent(channel) {
+      const emitter = new EventEmitter();
+      return {
+        config: { hostname: 'shutdown-producer-test', timeout: 10, rpcTimeout: 0 },
+        getDefaultChannel: sinon.stub().resolves(channel),
+        addListener(event, fn) {
+          emitter.on(event, fn);
+        },
+        emitClose() {
+          emitter.emit('close');
+        },
+      };
+    }
+
+    it('createRpcQueue() stops retrying (does not spin) once getDefaultChannel rejects with ConnectionClosedError', async () => {
+      const channel = createFakeChannelForRpc();
+      const connection = createFakeConnectionWithCloseEvent(channel);
+      connection.getDefaultChannel = sinon.stub().rejects(new ConnectionClosedError());
+      const producer = new Producer(connection);
+      const timeoutSpy = sandbox.spy(utils, 'timeoutPromise');
+
+      const result = await producer.createRpcQueue('shutdown:rpc:closed-from-start');
+
+      // one attempt, then the guard stops it: no internal retry-loop recursion, no delay-then-retry.
+      assert.strictEqual(result, undefined);
+      sinon.assert.notCalled(timeoutSpy);
+      sinon.assert.calledOnce(connection.getDefaultChannel);
+    });
+
+    it('the fire-and-forget reconnect-on-close listener stops spinning once the connection is permanently closed', async () => {
+      const channel = createFakeChannelForRpc();
+      const connection = createFakeConnectionWithCloseEvent(channel);
+      const producer = new Producer(connection);
+      const queue = 'shutdown:rpc:reconnect-then-closed';
+
+      // first init succeeds normally and registers the reconnect-on-close listener
+      await producer.createRpcQueue(queue);
+      sinon.assert.calledOnce(connection.getDefaultChannel);
+
+      // now simulate the connection being permanently closed
+      connection.getDefaultChannel = sinon.stub().rejects(new ConnectionClosedError());
+      const timeoutSpy = sandbox.spy(utils, 'timeoutPromise');
+
+      connection.emitClose(); // fires the registered listener, which fire-and-forgets createRpcQueue()
+
+      // give the fire-and-forget promise chain a tick to run to completion
+      await new Promise((resolve) => {
+        setTimeout(resolve, 20);
+      });
+
+      sinon.assert.calledOnce(connection.getDefaultChannel);
+      sinon.assert.notCalled(timeoutSpy);
+    });
+  });
+
+  // producer.js's stop() proactively rejects RPC promises pending in amqpRPCQueues (a separate code
+  // path from the reconnect-on-close guard above) so a caller awaiting an RPC response does not hang
+  // for the full rpcTimeout once the connection is gone.
+  describe('producer.js stop()', () => {
+    const sandbox = sinon.createSandbox();
+    afterEach(() => sandbox.restore());
+
+    function createFakeChannelForRpc() {
+      const channel = new EventEmitter();
+      channel.assertQueue = sinon.stub().resolves({});
+      channel.consume = sinon.stub().resolves({ consumerTag: 'fake-tag' });
+      channel.sendToQueue = sinon.stub().returns(true);
+      channel.publish = sinon.stub().returns(true);
+      return channel;
+    }
+
+    function createFakeConnection(channel, overrides = {}) {
+      return {
+        config: { hostname: 'shutdown-producer-stop-test', timeout: 10, rpcTimeout: 15000, ...overrides },
+        getDefaultChannel: sinon.stub().resolves(channel),
+        getConnection: sinon.stub().resolves({}),
+        addListener: sinon.stub(),
+      };
+    }
+
+    /** correlationId key registered in amqpRPCQueues[queue] for the pending waiter (not 'resQueuePromise'). */
+    function pendingCorrelationId(producer, queue) {
+      return Object.keys(producer.amqpRPCQueues[queue] || {}).find((key) => key !== 'resQueuePromise');
+    }
+
+    it('rejects a pending RPC promise with ConnectionClosedError instead of waiting out rpcTimeout', async () => {
+      const channel = createFakeChannelForRpc();
+      const connection = createFakeConnection(channel);
+      const producer = new Producer(connection);
+      const queue = 'shutdown:producer-stop:pending';
+
+      const rpcPromise = producer.checkRpc(queue, 'payload', { rpc: true });
+      // let createRpcQueue()/publishOrSendToQueue() settle so the waiter is actually registered
+      await utils.timeoutPromise(10);
+      assert(pendingCorrelationId(producer, queue), 'expected a pending RPC waiter to be registered');
+
+      producer.stop();
+
+      await assert.rejects(() => rpcPromise, ConnectionClosedError);
+    });
+
+    it('clears the pending timeout so no lingering timer keeps the process alive', async () => {
+      const channel = createFakeChannelForRpc();
+      const connection = createFakeConnection(channel, { rpcTimeout: 15000 });
+      const producer = new Producer(connection);
+      const queue = 'shutdown:producer-stop:clear-timeout';
+      const clearTimeoutSpy = sandbox.spy(global, 'clearTimeout');
+
+      const rpcPromise = producer.checkRpc(queue, 'payload', { rpc: true });
+      await utils.timeoutPromise(10);
+
+      const corrId = pendingCorrelationId(producer, queue);
+      assert(corrId, 'expected a pending RPC waiter to be registered');
+      const { timeoutId } = producer.amqpRPCQueues[queue][corrId];
+      assert(timeoutId, 'expected a timer to have been scheduled for the pending RPC');
+
+      producer.stop();
+
+      sinon.assert.calledWith(clearTimeoutSpy, timeoutId);
+      assert.strictEqual(
+        pendingCorrelationId(producer, queue),
+        undefined,
+        'expected the waiter to be removed from the registry',
+      );
+      await assert.rejects(() => rpcPromise, ConnectionClosedError);
+    });
+
+    it('is idempotent - calling stop() twice does not throw or double-reject', async () => {
+      const channel = createFakeChannelForRpc();
+      const connection = createFakeConnection(channel);
+      const producer = new Producer(connection);
+      const queue = 'shutdown:producer-stop:idempotent';
+
+      const rpcPromise = producer.checkRpc(queue, 'payload', { rpc: true });
+      await utils.timeoutPromise(10);
+
+      producer.stop();
+      producer.stop();
+
+      await assert.rejects(() => rpcPromise, ConnectionClosedError);
+      assert.strictEqual(producer._shuttingDown, true);
+    });
+
+    it('leaves resQueuePromise bookkeeping alone (only rejects correlationId waiters)', async () => {
+      const channel = createFakeChannelForRpc();
+      const connection = createFakeConnection(channel);
+      const producer = new Producer(connection);
+      const queue = 'shutdown:producer-stop:resqueue-untouched';
+
+      const rpcPromise = producer.checkRpc(queue, 'payload', { rpc: true });
+      await utils.timeoutPromise(10);
+
+      producer.stop();
+      await assert.rejects(() => rpcPromise, ConnectionClosedError);
+
+      assert(
+        producer.amqpRPCQueues[queue].resQueuePromise,
+        'expected resQueuePromise to still be present after stop()',
+      );
+    });
+  });
+
+  // src/modules/arnavmq.js's top-level close() orchestrates, in order: cancel -> drain (reject-pass
+  // on timeout) -> producer.stop() -> connection.close().
+  describe('arnavmq.js close() orchestration', () => {
+    const sandbox = sinon.createSandbox();
+    afterEach(() => sandbox.restore());
+
+    // A fresh, isolated ArnavMQ+Connection pair against the real broker - not the process-wide
+    // singleton every other spec file (including arnavmqConfigurator() calls elsewhere in this
+    // file) shares, since close() is terminal and would otherwise poison every test that runs after.
+    function newArnavmq(overrides = {}) {
+      const conn = new Connection({
+        host: 'amqp://localhost',
+        hostname: 'shutdown-arnavmq-close-test',
+        prefetch: 5,
+        timeout: 10,
+        requeue: true,
+        consumerSuffix: '',
+        producerMaxRetries: -1,
+        rpcTimeout: 0,
+        shutdownTimeout: 5000,
+        ...overrides,
+      });
+      return new ArnavMQ(conn);
+    }
+
+    /** Polls `predicate` every 20ms until truthy, or throws once `timeoutMs` elapses. */
+    async function waitFor(predicate, timeoutMs = 3000) {
+      const deadline = Date.now() + timeoutMs;
+      while (!predicate()) {
+        if (Date.now() >= deadline) {
+          throw new Error('waitFor() timed out');
+        }
+        await utils.timeoutPromise(20);
+      }
+    }
+
+    describe('the object returned by the top-level factory', () => {
+      it('exposes close(), connection.close()/isClosed, and the additive consumer sub-API', () => {
+        const arnavmq = arnavmqConfigurator();
+
+        assert.strictEqual(typeof arnavmq.close, 'function');
+        assert.strictEqual(typeof arnavmq.connection.close, 'function');
+        assert.strictEqual(typeof arnavmq.connection.isClosed, 'boolean');
+        assert.strictEqual(typeof arnavmq.consumer.consume, 'function');
+        assert.strictEqual(typeof arnavmq.consumer.subscribe, 'function');
+        assert.strictEqual(typeof arnavmq.consumer.cancel, 'function');
+        assert.strictEqual(typeof arnavmq.consumer.stop, 'function');
+        assert.strictEqual(typeof arnavmq.consumer.drain, 'function');
+        assert.strictEqual(typeof arnavmq.consumer.inFlight, 'function');
+      });
+
+      // `instanceof ConnectionClosedError` is how close()'s contract expects callers to detect the
+      // shutting-down rejection - it has to actually be constructible at runtime.
+      it('exposes ConnectionClosedError on the package entry point, usable with new and instanceof', () => {
+        assert.strictEqual(arnavmqConfigurator.ConnectionClosedError, ConnectionClosedError);
+        assert(
+          new arnavmqConfigurator.ConnectionClosedError() instanceof arnavmqConfigurator.ConnectionClosedError,
+          'expected require("arnavmq").ConnectionClosedError to be a real, constructible class',
+        );
+      });
+    });
+
+    it('cancels the subscription, drains the in-flight handler, lets it ack, then closes the connection', async () => {
+      const arnavmq = newArnavmq();
+      const queue = 'shutdown:arnavmq-close:cancel-drain-ack';
+      const gate = pDefer();
+      let callCount = 0;
+
+      await arnavmq.subscribe(queue, async () => {
+        callCount += 1;
+        await gate.promise;
+      });
+
+      await arnavmq.publish(queue, { n: 1 });
+      await waitFor(() => arnavmq.consumer.inFlight(queue) === 1);
+
+      const closePromise = arnavmq.close({ timeout: 5000 });
+      await utils.timeoutPromise(100); // give close() time to cancel and start draining
+
+      assert.strictEqual(arnavmq.connection.isClosed, false, 'connection must stay open while draining');
+      const [record] = [...arnavmq.consumer._subscriptions.values()];
+      assert.strictEqual(record.cancelled, true, 'expected close() to have cancelled the subscription by now');
+      assert.strictEqual(callCount, 1);
+
+      gate.resolve();
+      // close() reports the drain outcome back to the caller (finding #2): a clean drain, nothing abandoned.
+      assert.deepStrictEqual(await closePromise, { drained: true, abandoned: {} });
+
+      assert.strictEqual(callCount, 1, 'the cancelled subscription must not receive a second delivery');
+      assert.strictEqual(record.abandonedMessages.size, 0, 'the message drained cleanly, nothing should be abandoned');
+      assert.strictEqual(arnavmq.connection.isClosed, true);
+    });
+
+    it('rejects+requeues an in-flight message when the handler outlives the drain timeout', async () => {
+      const arnavmq = newArnavmq();
+      const queue = 'shutdown:arnavmq-close:timeout-reject';
+      const gate = pDefer();
+
+      await arnavmq.subscribe(queue, async () => {
+        await gate.promise;
+      });
+
+      await arnavmq.publish(queue, { n: 1 });
+      await waitFor(() => arnavmq.consumer.inFlight(queue) === 1);
+
+      const result = await arnavmq.close({ timeout: 100 });
+
+      // close() reports the drain outcome back to the caller (finding #2), keyed by queue name, so a
+      // caller can emit an abandoned-message metric off it.
+      assert.deepStrictEqual(result, { drained: false, abandoned: { [queue]: 1 } });
+      assert.strictEqual(arnavmq.connection.isClosed, true);
+      const [record] = [...arnavmq.consumer._subscriptions.values()];
+      assert.strictEqual(record.abandonedMessages.size, 1, 'expected the leftover message to be abandoned+requeued');
+
+      // let the still-running handler finish so it doesn't leak into later tests
+      gate.resolve();
+    });
+
+    it('calls producer.stop() before connection.close() - produce() during the drain window still succeeds; only fails with ConnectionClosedError once close() fully resolves', async () => {
+      const arnavmq = newArnavmq();
+      const queue = 'shutdown:arnavmq-close:producer-order';
+      const sideQueue = 'shutdown:arnavmq-close:producer-order:side';
+      const proceedGate = pDefer();
+      const publishSettled = pDefer();
+
+      await arnavmq.subscribe(queue, async () => {
+        await proceedGate.promise;
+        try {
+          await arnavmq.publish(sideQueue, { ok: true });
+          publishSettled.resolve({ ok: true });
+        } catch (error) {
+          publishSettled.resolve({ error });
+        }
+      });
+
+      await arnavmq.publish(queue, { n: 1 });
+      await waitFor(() => arnavmq.consumer.inFlight(queue) === 1);
+
+      const closePromise = arnavmq.close({ timeout: 5000 });
+      await utils.timeoutPromise(50); // close() is now cancelling/draining; the handler is still gated
+
+      assert.strictEqual(arnavmq.connection.isClosed, false, 'connection must still be open mid-drain');
+
+      proceedGate.resolve(); // let the handler publish downstream while the connection is still open
+      const publishOutcome = await publishSettled.promise;
+
+      assert.strictEqual(publishOutcome.error, undefined, 'expected produce() during the drain window to succeed');
+      assert.strictEqual(
+        arnavmq.connection.isClosed,
+        false,
+        'connection should still be open right after that publish resolved',
+      );
+
+      await closePromise;
+      assert.strictEqual(arnavmq.connection.isClosed, true);
+
+      await assert.rejects(() => arnavmq.publish(sideQueue, { late: true }), ConnectionClosedError);
+    });
+
+    it('is idempotent - repeated close() calls do not re-run the sequence or throw', async () => {
+      const arnavmq = newArnavmq();
+      const queue = 'shutdown:arnavmq-close:idempotent';
+      await arnavmq.subscribe(queue, () => {});
+
+      const cancelAllSpy = sandbox.spy(arnavmq.consumer, 'cancelAll');
+      const connectionCloseSpy = sandbox.spy(arnavmq.connection, 'close');
+
+      await Promise.all([arnavmq.close(), arnavmq.close()]);
+      await arnavmq.close();
+
+      assert.strictEqual(arnavmq.connection.isClosed, true);
+      // consumer.stop() memoizes its own shutdown promise, so cancelAll() only actually runs once no
+      // matter how many times the top-level close() calls into it.
+      sinon.assert.calledOnce(cancelAllSpy);
+      // the top-level close() itself is called 3 times above and must not throw on any of them.
+      sinon.assert.calledThrice(connectionCloseSpy);
+    });
+
+    // A drained handler's `channel.ack()` is fire-and-forget on the wire, so tearing the raw
+    // connection down right after it races that ack against the broker's requeue-everything-
+    // still-unacked cleanup. `Channels.closeAll()` (awaited by `Connection._close()` before the
+    // socket goes) is the barrier that removes the race - `Channel.Close` round-trips, so the broker
+    // has demonstrably processed the ack by the time close() returns.
+    it('a cleanly drained+acked message is never redelivered to a fresh instance after close()', async () => {
+      const arnavmq = newArnavmq();
+      const queue = 'shutdown:arnavmq-close:no-redelivery';
+
+      // Start from a known-empty queue: a message left behind by an earlier failing run of this very
+      // test would be indistinguishable from the redelivery this test is looking for.
+      const setupChannel = await arnavmq.connection.getDefaultChannel();
+      await setupChannel.assertQueue(queue, { durable: true });
+      await setupChannel.purgeQueue(queue);
+
+      const gate = pDefer();
+      let callCount = 0;
+      await arnavmq.subscribe(queue, async () => {
+        callCount += 1;
+        await gate.promise;
+      });
+
+      await arnavmq.publish(queue, { n: 1 });
+      await waitFor(() => arnavmq.consumer.inFlight(queue) === 1);
+
+      const closePromise = arnavmq.close({ timeout: 5000 });
+      await utils.timeoutPromise(50); // close() has cancelled and is draining; the handler is gated
+      gate.resolve(); // handler finishes and acks well inside the 5s drain budget
+      await closePromise;
+
+      const [record] = [...arnavmq.consumer._subscriptions.values()];
+      assert.strictEqual(callCount, 1);
+      assert.strictEqual(
+        record.abandonedMessages.size,
+        0,
+        'expected a clean drain (nothing abandoned/rejected) - this test is about the acked path',
+      );
+      assert.strictEqual(arnavmq.connection.isClosed, true);
+
+      // The actual proof, from outside the closed instance: an independent ArnavMQ+Connection pair on
+      // the same queue must never be handed that message. Any broker-side requeue would have happened
+      // when the first instance's connection dropped - i.e. before this one even connects - so a
+      // redelivery lands as soon as this consumer registers, well inside the window below.
+      const fresh = newArnavmq();
+      let redelivered;
+      await fresh.subscribe(queue, (body) => {
+        redelivered = body;
+      });
+      await utils.timeoutPromise(1500);
+
+      assert.strictEqual(
+        redelivered,
+        undefined,
+        `expected the acked message to be gone for good, but it was redelivered: ${JSON.stringify(redelivered)}`,
+      );
+
+      await fresh.close();
+    });
+
+    it('close({ timeout }) on a handler that outlives it resolves quickly, and a fresh instance receives the rejected+requeued message', async () => {
+      const arnavmq = newArnavmq();
+      const queue = 'shutdown:arnavmq-close:timeout-reject-redelivered';
+      const gate = pDefer(); // deliberately never resolved here - simulates the 5s+ handler that outlives the drain timeout
+
+      await arnavmq.subscribe(queue, async () => {
+        await gate.promise;
+      });
+
+      await arnavmq.publish(queue, { n: 1 });
+      await waitFor(() => arnavmq.consumer.inFlight(queue) === 1);
+
+      const start = Date.now();
+      await arnavmq.close({ timeout: 100 });
+      const elapsed = Date.now() - start;
+
+      assert(elapsed < 2000, `expected close({ timeout: 100 }) to resolve in ~100ms, took ${elapsed}ms`);
+      assert.strictEqual(arnavmq.connection.isClosed, true);
+
+      const fresh = newArnavmq();
+      const receivedDefer = pDefer();
+      let received;
+      await fresh.subscribe(queue, (body) => {
+        received = body;
+        receivedDefer.resolve();
+      });
+
+      // resolves once the requeued message is actually redelivered to this independent consumer;
+      // if it were lost instead of requeued, this hangs until mocha's suite timeout fails the test.
+      await receivedDefer.promise;
+      assert.strictEqual(received.n, 1);
+
+      gate.resolve(); // let the first instance's still-running handler finish so it doesn't leak
+      await fresh.close();
+    });
+
+    // cancelAll() must mark every record cancelled before the channel's/connection's own 'close'
+    // event fires, or the onChannelClose listener would try to resubscribe against a connection
+    // that's being torn down.
+    it('after close(), _consumeQueue is never invoked again - no resubscribe fight with the closing connection', async () => {
+      const arnavmq = newArnavmq();
+      const queue = 'shutdown:arnavmq-close:no-resubscribe-fight';
+      await arnavmq.subscribe(queue, () => {});
+
+      const consumeQueueSpy = sandbox.spy(arnavmq.consumer, '_consumeQueue');
+
+      await arnavmq.close();
+
+      // give any 'close' event fired by the now-dead channel/connection a moment to propagate - if
+      // the shutting-down/cancelled guard on the resubscribe listener were missing or ordered wrong,
+      // this is when a resubscribe attempt (and another _consumeQueue call) would happen.
+      await utils.timeoutPromise(200);
+
+      sinon.assert.notCalled(consumeQueueSpy);
+      assert.strictEqual(arnavmq.connection.isClosed, true);
+    });
+
+    it('a pending RPC call rejects when close() runs, instead of hanging for rpcTimeout', async () => {
+      const arnavmq = newArnavmq({ rpcTimeout: 15000 });
+      const queue = 'shutdown:arnavmq-close:pending-rpc';
+      // deliberately no consumer subscribed on `queue` - this RPC call never gets answered on its own.
+
+      const rpcPromise = arnavmq.publish(queue, { ping: true }, { rpc: true });
+      await utils.timeoutPromise(100); // let checkRpc()/createRpcQueue() register the pending waiter
+
+      // Attach the rejection expectation *before/alongside* close(), not after awaiting it: close()
+      // rejects rpcPromise synchronously from inside producer.stop(), several steps before close()
+      // itself resolves (it still has to await connection.close()). Awaiting close() to completion
+      // first and only then attaching a handler to rpcPromise leaves it unhandled across a real
+      // async gap, which trips Node's unhandledRejection detection - a test-harness ordering issue,
+      // not a bug in close() itself.
+      const start = Date.now();
+      await Promise.all([arnavmq.close(), assert.rejects(() => rpcPromise, ConnectionClosedError)]);
+      const elapsed = Date.now() - start;
+
+      assert(
+        elapsed < 5000,
+        `expected close() to resolve quickly rather than waiting out rpcTimeout, took ${elapsed}ms`,
+      );
+    });
+  });
+});

--- a/test/shutdown-spec.js
+++ b/test/shutdown-spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-underscore-dangle */
 const assert = require('assert');
 const sinon = require('sinon');
 const EventEmitter = require('events');
@@ -11,9 +12,9 @@ const { setLogger } = require('../src/modules/logger');
 const utils = require('../src/modules/utils');
 
 /**
- * A fake amqp.node channel good enough to drive consumer.js without a broker: it captures the
- * per-queue consume() callback so tests can deliver fake messages into it directly, and exposes
- * spies for every broker call consumer.js can make on a channel.
+ * A fake amqp.node channel good enough to drive consumer.js and producer.js without a broker: it
+ * captures the per-queue consume() callback so tests can deliver fake messages into it directly,
+ * and exposes spies for every broker call either module can make on a channel.
  */
 function createFakeChannel() {
   const channel = new EventEmitter();
@@ -28,14 +29,24 @@ function createFakeChannel() {
   channel.cancel = sinon.stub().resolves();
   channel.close = sinon.stub().resolves();
   channel.sendToQueue = sinon.stub().returns(true);
+  channel.publish = sinon.stub().returns(true);
   return channel;
 }
 
 function createFakeConnection(channel, overrides = {}) {
   return {
-    config: { prefetch: 5, timeout: 10, requeue: true, consumerSuffix: '', ...overrides },
+    config: {
+      prefetch: 5,
+      timeout: 10,
+      requeue: true,
+      consumerSuffix: '',
+      hostname: 'shutdown-fake-connection',
+      rpcTimeout: 15000,
+      ...overrides,
+    },
     getChannel: sinon.stub().resolves(channel),
     getDefaultChannel: sinon.stub().resolves(channel),
+    getConnection: sinon.stub().resolves({}),
   };
 }
 
@@ -71,14 +82,41 @@ async function cancelQueue(consumer, queue) {
   await Promise.all(subscriptions.map((sub) => consumer._cancelSubscription(sub)));
 }
 
-/** A fake amqp.node channel good enough to drive producer.js's RPC path without a broker. */
-function createFakeChannelForRpc() {
-  const channel = new EventEmitter();
-  channel.assertQueue = sinon.stub().resolves({});
-  channel.consume = sinon.stub().resolves({ consumerTag: 'fake-tag' });
-  channel.sendToQueue = sinon.stub().returns(true);
-  channel.publish = sinon.stub().returns(true);
-  return channel;
+/**
+ * A Connection against the real broker, built from the exported class rather than the module's
+ * singleton factory, so close() (which is terminal) never tears down what the other spec files use.
+ */
+function newConnection(overrides = {}) {
+  return new Connection({
+    host: 'amqp://localhost',
+    hostname: 'shutdown-test',
+    prefetch: 5,
+    timeout: 10,
+    requeue: true,
+    consumerSuffix: '',
+    producerMaxRetries: -1,
+    rpcTimeout: 0,
+    ...overrides,
+  });
+}
+
+/** A fresh, isolated ArnavMQ + Connection pair against the real broker. */
+function newArnavmq(overrides = {}) {
+  return new ArnavMQ(newConnection(overrides));
+}
+
+/** The correlationId of the pending RPC waiter registered in amqpRPCQueues[queue], if any. */
+function pendingCorrelationId(producer, queue) {
+  return Object.keys(producer.amqpRPCQueues[queue] || {}).find((key) => key !== 'resQueuePromise');
+}
+
+/** A producer with one RPC request already published and waiting for its response. */
+async function newPendingRpc(queue, overrides = {}) {
+  const channel = createFakeChannel();
+  const producer = new Producer(createFakeConnection(channel, overrides));
+  const rpcPromise = producer.checkRpc(queue, 'payload', { rpc: true });
+  await waitFor(() => !!pendingCorrelationId(producer, queue));
+  return { channel, producer, rpcPromise };
 }
 
 /** Polls `predicate` every 20ms until truthy, or throws once `timeoutMs` elapses. */
@@ -86,10 +124,29 @@ async function waitFor(predicate, timeoutMs = 3000) {
   const deadline = Date.now() + timeoutMs;
   while (!predicate()) {
     if (Date.now() >= deadline) {
-      throw new Error('waitFor() timed out');
+      throw new Error(`waitFor() timed out after ${timeoutMs}ms waiting for: ${predicate}`);
     }
     await utils.timeoutPromise(20);
   }
+}
+
+/**
+ * Runs `fn` and resolves with its result, or with the error it threw. For work done inside a
+ * consumer handler, where consumer.js swallows a throw into a reject+log and the test would
+ * otherwise never see it.
+ */
+async function settled(fn) {
+  try {
+    return await fn();
+  } catch (error) {
+    return error;
+  }
+}
+
+/** Resolves once close()'s cancel step has landed on every subscription registered on `mq`. */
+function waitForCancelled(mq) {
+  const subscriptions = mq.consumer._subscriptions;
+  return waitFor(() => subscriptions.length > 0 && subscriptions.every((sub) => sub.cancelled));
 }
 
 /**
@@ -146,7 +203,7 @@ describe('graceful shutdown', () => {
         const queue = 'shutdown:cancel:no-close';
         await consumer.consume(queue, () => {});
 
-        const record = [...consumer._subscriptions.values()][0];
+        const record = consumer._subscriptions[0];
         assert(record.consumerTag, 'expected a consumerTag to have been assigned');
         const { channel } = record;
         const closeSpy = sandbox.spy(channel, 'close');
@@ -166,7 +223,7 @@ describe('graceful shutdown', () => {
       // proves the *consequence* end-to-end against the real broker - a live queueB consumer and a
       // live producer RPC round-trip both keep working concurrently with cancelling queueA, and
       // queueA itself really stops receiving.
-      it('cancelling queueA stops A while a concurrent queueB consumer and a producer RPC call keep working (regression: cancel by tag, never close the shared channel)', async () => {
+      it('cancelling queueA leaves a concurrent queueB consumer and a producer RPC round-trip working', async () => {
         const queueA = 'shutdown:cancel:regression:a';
         const queueB = 'shutdown:cancel:regression:b';
         const rpcQueue = 'shutdown:cancel:regression:rpc';
@@ -182,8 +239,7 @@ describe('graceful shutdown', () => {
         await consumer.consume(rpcQueue, () => 'pong');
 
         await arnavmq.producer.produce(queueA, { n: 1 });
-        await utils.timeoutPromise(300);
-        assert.strictEqual(countA, 1, 'expected queueA to receive its message before being cancelled');
+        await waitFor(() => countA === 1);
 
         await cancelQueue(consumer, queueA);
 
@@ -194,10 +250,9 @@ describe('graceful shutdown', () => {
           arnavmq.producer.produce(queueB, { n: 1 }),
           arnavmq.producer.produce(queueA, { n: 2 }),
         ]);
-        await utils.timeoutPromise(300);
+        await waitFor(() => countB === 1); // queueB keeps receiving after queueA was cancelled
 
         assert.strictEqual(rpcResult, 'pong', 'expected the RPC round-trip to keep working after cancelling queueA');
-        assert.strictEqual(countB, 1, 'expected queueB to keep receiving messages after cancelling queueA');
         assert.strictEqual(countA, 1, 'the cancelled queueA subscription must not receive further deliveries');
       });
 
@@ -209,7 +264,7 @@ describe('graceful shutdown', () => {
         // so it is visible on the registry immediately even though the returned promise is still
         // pending (stuck in the retry loop because _initializeChannel always resolves null here).
         const subscribePromise = consumer.subscribe(queue, () => {});
-        const record = [...consumer._subscriptions.values()].find((r) => r.queue === queue);
+        const record = consumer._subscriptions.find((r) => r.queue === queue);
         assert(record, 'expected a record to be registered synchronously by subscribe()');
         assert.strictEqual(record.consumerTag, null);
 
@@ -225,7 +280,7 @@ describe('graceful shutdown', () => {
         const initStub = sandbox.stub(consumer, '_initializeChannel').resolves(null);
 
         const subscribePromise = consumer.subscribe(queue, () => {});
-        const record = [...consumer._subscriptions.values()].find((r) => r.queue === queue);
+        const record = consumer._subscriptions.find((r) => r.queue === queue);
         assert(record, 'expected a record to be registered synchronously by subscribe()');
 
         await cancelQueue(consumer, queue);
@@ -240,9 +295,8 @@ describe('graceful shutdown', () => {
         );
       });
 
-      it('_cancelAll() sets _shuttingDown so even brand-new subscribe() calls never consume', async () => {
-        await consumer._cancelAll();
-        assert.strictEqual(consumer._shuttingDown, true);
+      it('after stop(), even brand-new subscribe() calls never consume', async () => {
+        await consumer.stop();
 
         const initSpy = sandbox.spy(consumer, '_initializeChannel');
         const result = await consumer.subscribe('shutdown:after-cancel-all', () => {});
@@ -255,19 +309,9 @@ describe('graceful shutdown', () => {
     describe('listener hygiene on the shared channel', () => {
       it('does not accumulate close listeners across repeated _initializeChannel calls for one record', async () => {
         const { channel: sharedChannel, consumer } = newTestConsumer();
-        const record = {
-          id: 1,
-          queue: 'shared-channel-queue',
-          options: { channel: {} },
-          callback: () => {},
-          channel: null,
-          consumerTag: null,
-          onChannelClose: null,
-          cancelled: false,
-          inFlightCount: 0,
-        };
 
-        await consumer._initializeChannel(record);
+        await consumer.consume('shared-channel-queue', () => {});
+        const record = consumer._subscriptions[0];
         await consumer._initializeChannel(record);
         await consumer._initializeChannel(record);
 
@@ -278,7 +322,7 @@ describe('graceful shutdown', () => {
         const { channel: sharedChannel, consumer } = newTestConsumer();
 
         await consumer.consume('shutdown:onclose:guard', () => {});
-        const record = [...consumer._subscriptions.values()][0];
+        const record = consumer._subscriptions[0];
         const subscribeSpy = sinon.spy(consumer, '_subscribe');
 
         record.cancelled = true;
@@ -287,7 +331,7 @@ describe('graceful shutdown', () => {
         sinon.assert.notCalled(subscribeSpy);
       });
 
-      it('_cancelSubscription removes the record close listener, so repeated subscribe->cancel cycles do not leak listeners', async () => {
+      it('repeated subscribe->cancel cycles leave no listener and no record behind', async () => {
         const { channel: sharedChannel, consumer } = newTestConsumer();
         const queue = 'shutdown:cancel:listener-hygiene';
 
@@ -321,7 +365,7 @@ describe('graceful shutdown', () => {
         const queue = 'shutdown:cancel:mid-flight';
 
         await consumer.consume(queue, () => {});
-        const [first] = [...consumer._subscriptions.values()];
+        const [first] = consumer._subscriptions;
         assert(first.consumerTag, 'expected the first subscription to be fully subscribed');
 
         // The second one is held inside channel.consume() - i.e. past _initializeChannel (so
@@ -334,11 +378,10 @@ describe('graceful shutdown', () => {
         });
 
         const subscribePromise = consumer.consume(queue, () => {});
-        await utils.timeoutPromise(20); // let it reach the gated channel.consume()
-        const second = [...consumer._subscriptions.values()][1];
+        await waitFor(() => channel.consume.called); // it has reached the gated channel.consume()
+        const second = consumer._subscriptions[1];
         assert(second, 'expected the second subscription to be registered');
         assert.strictEqual(second.consumerTag, null, 'expected it to be mid-flight, without a tag yet');
-        sinon.assert.called(channel.consume);
 
         // cancelling here can send nothing to the broker - there is no tag yet.
         await cancelQueue(consumer, queue);
@@ -371,8 +414,8 @@ describe('graceful shutdown', () => {
         });
 
         const subscribePromise = consumer.subscribe(queue, () => {});
-        await utils.timeoutPromise(20); // let it reach the gated assertQueue()
-        const record = [...consumer._subscriptions.values()][0];
+        await waitFor(() => channel.assertQueue.called); // it has reached the gated assertQueue()
+        const record = consumer._subscriptions[0];
         assert(record.channel, 'expected _initializeChannel to have already attached the shared channel');
         assert.strictEqual(record.consumerTag, null);
 
@@ -396,26 +439,26 @@ describe('graceful shutdown', () => {
         const ackQueue = 'shutdown:inflight:ack-path';
         let observedDuringAckHandler = null;
         await consumer.consume(ackQueue, () => {
-          observedDuringAckHandler = consumer.inFlight(ackQueue);
+          observedDuringAckHandler = consumer.inFlight();
           return 'ok';
         });
 
-        assert.strictEqual(consumer.inFlight(ackQueue), 0);
+        assert.strictEqual(consumer.inFlight(), 0);
         await deliver(channel, ackQueue, fakeMessage({ a: 1 }));
         assert.strictEqual(observedDuringAckHandler, 1, 'expected inFlight() to be 1 while the handler runs');
-        assert.strictEqual(consumer.inFlight(ackQueue), 0, 'expected inFlight() back to 0 once acked');
+        assert.strictEqual(consumer.inFlight(), 0, 'expected inFlight() back to 0 once acked');
         sinon.assert.calledOnce(channel.ack);
 
         const rejectQueue = 'shutdown:inflight:reject-path';
         let observedDuringRejectHandler = null;
         await consumer.consume(rejectQueue, () => {
-          observedDuringRejectHandler = consumer.inFlight(rejectQueue);
+          observedDuringRejectHandler = consumer.inFlight();
           throw new Error('boom');
         });
 
         await deliver(channel, rejectQueue, fakeMessage({ a: 1 }));
         assert.strictEqual(observedDuringRejectHandler, 1, 'expected inFlight() to be 1 while the handler runs');
-        assert.strictEqual(consumer.inFlight(rejectQueue), 0, 'expected inFlight() back to 0 once rejected');
+        assert.strictEqual(consumer.inFlight(), 0, 'expected inFlight() back to 0 once rejected');
         sinon.assert.calledOnce(channel.reject);
       });
 
@@ -428,13 +471,13 @@ describe('graceful shutdown', () => {
           handlerCalls += 1;
           return 'ok';
         });
-        const record = [...consumer._subscriptions.values()][0];
+        const record = consumer._subscriptions[0];
         record.cancelled = true; // simulates a delivery buffered before cancel-ok landed
 
         await deliver(channel, queue, fakeMessage({ a: 1 }));
 
         assert.strictEqual(handlerCalls, 0, 'the handler must not run for a message delivered after cancel');
-        assert.strictEqual(consumer.inFlight(queue), 0);
+        assert.strictEqual(consumer.inFlight(), 0);
         sinon.assert.calledOnce(channel.reject);
         sinon.assert.calledWith(channel.reject, sinon.match.any, true);
         sinon.assert.notCalled(channel.ack);
@@ -457,7 +500,7 @@ describe('graceful shutdown', () => {
         await consumer.consume(queue, () => handlerDefer.promise);
         const deliverPromise = deliver(channel, queue, fakeMessage({ a: 1 }));
 
-        assert.strictEqual(consumer.inFlight(queue), 1);
+        assert.strictEqual(consumer.inFlight(), 1);
         const drainPromise = consumer._drain();
 
         handlerDefer.resolve('ok');
@@ -498,7 +541,6 @@ describe('graceful shutdown', () => {
         await consumer.stop();
         sinon.assert.called(channel.cancel);
         sinon.assert.notCalled(channel.close);
-        assert.strictEqual(consumer._shuttingDown, true);
       });
 
       it('is idempotent - concurrent calls share one in-flight shutdown', async () => {
@@ -536,62 +578,41 @@ describe('graceful shutdown', () => {
       });
     });
 
-    describe('inFlight()', () => {
-      it('inFlight() counts across all queues', async () => {
-        const { channel, consumer } = newTestConsumer();
-        const queueA = 'shutdown:inflight:scope-a';
-        const queueB = 'shutdown:inflight:scope-b';
-        const deferA = pDefer();
-        const deferB = pDefer();
+    it('inFlight() counts across all queues', async () => {
+      const { channel, consumer } = newTestConsumer();
+      const queueA = 'shutdown:inflight:scope-a';
+      const queueB = 'shutdown:inflight:scope-b';
+      const deferA = pDefer();
+      const deferB = pDefer();
 
-        await consumer.consume(queueA, () => deferA.promise);
-        await consumer.consume(queueB, () => deferB.promise);
+      await consumer.consume(queueA, () => deferA.promise);
+      await consumer.consume(queueB, () => deferB.promise);
 
-        const deliverA = deliver(channel, queueA, fakeMessage({ a: 1 }));
-        const deliverB = deliver(channel, queueB, fakeMessage({ b: 1 }));
+      const deliverA = deliver(channel, queueA, fakeMessage({ a: 1 }));
+      const deliverB = deliver(channel, queueB, fakeMessage({ b: 1 }));
 
-        assert.strictEqual(consumer.inFlight(), 2);
+      assert.strictEqual(consumer.inFlight(), 2);
 
-        deferA.resolve('ok');
-        deferB.resolve('ok');
-        await Promise.all([deliverA, deliverB]);
+      deferA.resolve('ok');
+      deferB.resolve('ok');
+      await Promise.all([deliverA, deliverB]);
 
-        assert.strictEqual(consumer.inFlight(), 0);
-      });
+      assert.strictEqual(consumer.inFlight(), 0);
     });
   });
 
-  // These tests construct their own `Connection` instances (via the exported `Connection` class,
-  // not the module's singleton factory) so they can freely call `close()` against a real broker
-  // connection without tearing down the shared singleton every other spec file in this suite relies
-  // on.
   describe('connection.js', () => {
     const sandbox = sinon.createSandbox();
     afterEach(() => sandbox.restore());
 
-    function newConnection(overrides = {}) {
-      return new Connection({
-        host: 'amqp://localhost',
-        hostname: 'shutdown-connection-test',
-        timeout: 10,
-        ...overrides,
-      });
-    }
+    it('isClosed is false before close() and true as soon as close() is invoked, before it resolves', () => {
+      const conn = newConnection();
+      assert.strictEqual(conn.isClosed, false);
 
-    describe('isClosed', () => {
-      it('is false before close() and true as soon as close() is invoked (before it even resolves)', () => {
-        const conn = newConnection();
-        assert.strictEqual(conn.isClosed, false);
+      const closePromise = conn.close();
+      assert.strictEqual(conn.isClosed, true, 'expected isClosed to flip synchronously, before any await in close()');
 
-        const closePromise = conn.close();
-        assert.strictEqual(
-          conn.isClosed,
-          true,
-          'expected _closed to flip synchronously, before any await inside close()',
-        );
-
-        return closePromise;
-      });
+      return closePromise;
     });
 
     describe('close()', () => {
@@ -709,36 +730,11 @@ describe('graceful shutdown', () => {
         assert.strictEqual(conn.isClosed, true);
       });
 
-      it('gives up on a channel that never confirms its close rather than hanging shutdown forever', async () => {
-        const conn = newConnection({ prefetch: 5 });
-        const amqpConnection = await conn.getConnection();
-        const channel = await conn.getDefaultChannel();
-        const connectionCloseSpy = sandbox.spy(amqpConnection, 'close');
-        // amqplib leaves `channel.close()` pending forever if the Channel.Close-Ok never arrives (the
-        // socket dying mid-handshake does not settle it, nor does a simultaneous server-side close).
-        // The barrier is best-effort: it must be capped, or a wedged broker means a pod that never exits.
-        sandbox.stub(channel, 'close').returns(new Promise(() => {}));
-
-        const start = Date.now();
-        await conn.close();
-        const elapsed = Date.now() - start;
-
-        sinon.assert.calledOnce(connectionCloseSpy);
-        assert.strictEqual(conn.isClosed, true);
-        assert(elapsed >= 4000, `expected close() to actually wait out the channel-close cap, took only ${elapsed}ms`);
-        assert(elapsed < 15000, `expected close() to give up on the wedged channel, took ${elapsed}ms`);
-      });
-
-      it('gives up on a channel whose creation never finishes rather than hanging shutdown forever', async () => {
-        const conn = newConnection({ prefetch: 5 });
+      // The channel-close barrier is best-effort and has to be capped, or one wedged channel means a
+      // pod that never exits. Both tests below wedge a different step of it.
+      async function assertClosesByWaitingOutTheCap(conn, what) {
         const amqpConnection = await conn.getConnection();
         const connectionCloseSpy = sandbox.spy(amqpConnection, 'close');
-
-        // A cache entry still pending when shutdown starts - a channel allocated moments earlier whose
-        // Channel.Open-Ok/Basic.Qos-Ok never arrived from a broker that stopped answering while its TCP
-        // connection stayed up. The cap has to cover awaiting the entry itself, not just close().
-        // eslint-disable-next-line no-underscore-dangle
-        conn._channels._channels.set('never-opens', { chann: new Promise(() => {}), config: { prefetch: 5 } });
 
         const start = Date.now();
         await conn.close();
@@ -747,7 +743,29 @@ describe('graceful shutdown', () => {
         sinon.assert.calledOnce(connectionCloseSpy);
         assert.strictEqual(conn.isClosed, true);
         assert(elapsed >= 4000, `expected close() to actually wait out the cap, took only ${elapsed}ms`);
-        assert(elapsed < 15000, `expected close() to give up on the never-opened channel, took ${elapsed}ms`);
+        assert(elapsed < 15000, `expected close() to give up on the ${what}, took ${elapsed}ms`);
+      }
+
+      it('gives up on a channel that never confirms its close rather than hanging shutdown forever', async () => {
+        const conn = newConnection();
+        const channel = await conn.getDefaultChannel();
+        // amqplib leaves `channel.close()` pending forever if the Channel.Close-Ok never arrives - the
+        // socket dying mid-handshake does not settle it, nor does a simultaneous server-side close.
+        sandbox.stub(channel, 'close').returns(new Promise(() => {}));
+
+        await assertClosesByWaitingOutTheCap(conn, 'wedged channel');
+      });
+
+      it('gives up on a channel whose creation never finishes rather than hanging shutdown forever', async () => {
+        const conn = newConnection();
+        await conn.getConnection();
+
+        // A cache entry still pending when shutdown starts - a channel allocated moments earlier whose
+        // Channel.Open-Ok/Basic.Qos-Ok never arrived from a broker that stopped answering while its TCP
+        // connection stayed up. The cap has to cover awaiting the entry itself, not just close().
+        conn._channels._channels.set('never-opens', { chann: new Promise(() => {}), config: { prefetch: 5 } });
+
+        await assertClosesByWaitingOutTheCap(conn, 'never-opened channel');
       });
     });
 
@@ -764,10 +782,7 @@ describe('graceful shutdown', () => {
 
         const channelPromise = conn.getDefaultChannel();
         // wait until we are inside the prefetch round-trip, with the channel allocated but qos pending
-        for (let i = 0; i < 100 && !fakeChannel.prefetch.called; i += 1) {
-          await utils.timeoutPromise(10);
-        }
-        sinon.assert.calledOnce(fakeChannel.prefetch);
+        await waitFor(() => fakeChannel.prefetch.called);
 
         assert.strictEqual(fakeChannel.listenerCount('error'), 1, "expected the 'error' listener on before prefetch");
         assert.strictEqual(fakeChannel.listenerCount('close'), 1, "expected the 'close' listener on before prefetch");
@@ -789,13 +804,7 @@ describe('graceful shutdown', () => {
         await conn.getConnection();
         await conn.close();
 
-        await assert.rejects(
-          () => conn.getConnection(),
-          (err) => {
-            assert(err instanceof ConnectionClosedError, `expected ConnectionClosedError, got ${err.constructor.name}`);
-            return true;
-          },
-        );
+        await assert.rejects(() => conn.getConnection(), ConnectionClosedError);
       });
 
       it('also rejects for a connection that was never connected before close()', async () => {
@@ -831,26 +840,22 @@ describe('graceful shutdown', () => {
         });
       }
 
-      it('getChannel() rejects with ConnectionClosedError instead of creating an orphan channel', async () => {
-        const conn = newConnection();
-        const amqpConnection = await conn.getConnection();
-        const createChannelSpy = sandbox.spy(amqpConnection, 'createChannel');
+      const accessors = {
+        'getChannel()': (conn) => conn.getChannel('some-queue', {}),
+        'getDefaultChannel()': (conn) => conn.getDefaultChannel(),
+      };
 
-        driveCloseIntoTheGap(conn);
+      Object.entries(accessors).forEach(([name, getChannel]) => {
+        it(`${name} rejects with ConnectionClosedError instead of creating an orphan channel`, async () => {
+          const conn = newConnection();
+          const amqpConnection = await conn.getConnection();
+          const createChannelSpy = sandbox.spy(amqpConnection, 'createChannel');
 
-        await assert.rejects(() => conn.getChannel('some-queue', {}), ConnectionClosedError);
-        sinon.assert.notCalled(createChannelSpy);
-      });
+          driveCloseIntoTheGap(conn);
 
-      it('getDefaultChannel() rejects with ConnectionClosedError instead of creating an orphan channel', async () => {
-        const conn = newConnection();
-        const amqpConnection = await conn.getConnection();
-        const createChannelSpy = sandbox.spy(amqpConnection, 'createChannel');
-
-        driveCloseIntoTheGap(conn);
-
-        await assert.rejects(() => conn.getDefaultChannel(), ConnectionClosedError);
-        sinon.assert.notCalled(createChannelSpy);
+          await assert.rejects(() => getChannel(conn), ConnectionClosedError);
+          sinon.assert.notCalled(createChannelSpy);
+        });
       });
     });
   });
@@ -863,26 +868,8 @@ describe('graceful shutdown', () => {
     const sandbox = sinon.createSandbox();
     afterEach(() => sandbox.restore());
 
-    function createFakeConnection(channel, overrides = {}) {
-      return {
-        config: { hostname: 'shutdown-producer-test', timeout: 10, rpcTimeout: 15000, ...overrides },
-        getDefaultChannel: sinon.stub().resolves(channel),
-        getConnection: sinon.stub().resolves({}),
-      };
-    }
-
-    /** correlationId key registered in amqpRPCQueues[queue] for the pending waiter (not 'resQueuePromise'). */
-    function pendingCorrelationId(producer, queue) {
-      return Object.keys(producer.amqpRPCQueues[queue] || {}).find((key) => key !== 'resQueuePromise');
-    }
-
     it('rejects a pending RPC promise with ConnectionClosedError instead of waiting out rpcTimeout', async () => {
-      const channel = createFakeChannelForRpc();
-      const producer = new Producer(createFakeConnection(channel));
-      const queue = 'shutdown:producer-close:pending';
-
-      const rpcPromise = producer.checkRpc(queue, 'payload', { rpc: true });
-      await waitFor(() => !!pendingCorrelationId(producer, queue));
+      const { channel, rpcPromise } = await newPendingRpc('shutdown:producer-close:pending');
 
       channel.emit('close');
 
@@ -890,15 +877,11 @@ describe('graceful shutdown', () => {
     });
 
     it('clears the pending timeout so no lingering timer keeps the process alive', async () => {
-      const channel = createFakeChannelForRpc();
-      const producer = new Producer(createFakeConnection(channel));
-      const queue = 'shutdown:producer-close:clear-timeout';
       const clearTimeoutSpy = sandbox.spy(global, 'clearTimeout');
+      const queue = 'shutdown:producer-close:clear-timeout';
+      const { channel, producer, rpcPromise } = await newPendingRpc(queue);
 
-      const rpcPromise = producer.checkRpc(queue, 'payload', { rpc: true });
-      await waitFor(() => !!pendingCorrelationId(producer, queue));
-      const corrId = pendingCorrelationId(producer, queue);
-      const { timeoutId } = producer.amqpRPCQueues[queue][corrId];
+      const { timeoutId } = producer.amqpRPCQueues[queue][pendingCorrelationId(producer, queue)];
       assert(timeoutId, 'expected a timer to have been scheduled for the pending RPC');
 
       channel.emit('close');
@@ -908,12 +891,8 @@ describe('graceful shutdown', () => {
     });
 
     it('drops the dead reply-queue bookkeeping, so the next RPC publish rebuilds it', async () => {
-      const channel = createFakeChannelForRpc();
-      const producer = new Producer(createFakeConnection(channel));
       const queue = 'shutdown:producer-close:resqueue-rebuilt';
-
-      const rpcPromise = producer.checkRpc(queue, 'payload', { rpc: true });
-      await waitFor(() => !!pendingCorrelationId(producer, queue));
+      const { channel, producer, rpcPromise } = await newPendingRpc(queue);
       assert(producer.amqpRPCQueues[queue].resQueuePromise, 'expected a reply queue to have been set up');
 
       channel.emit('close');
@@ -926,12 +905,7 @@ describe('graceful shutdown', () => {
     });
 
     it('is idempotent - a second close does not throw or double-reject', async () => {
-      const channel = createFakeChannelForRpc();
-      const producer = new Producer(createFakeConnection(channel));
-      const queue = 'shutdown:producer-close:idempotent';
-
-      const rpcPromise = producer.checkRpc(queue, 'payload', { rpc: true });
-      await waitFor(() => !!pendingCorrelationId(producer, queue));
+      const { channel, rpcPromise } = await newPendingRpc('shutdown:producer-close:idempotent');
 
       channel.emit('close');
       channel.emit('close');
@@ -943,7 +917,7 @@ describe('graceful shutdown', () => {
     // remove-then-add in _initializeRpcQueue does - without piling up one listener per RPC queue on
     // the channel every consumer and the reply path share.
     it('stays at exactly one listener on the channel however many RPC queues are initialized', async () => {
-      const channel = createFakeChannelForRpc();
+      const channel = createFakeChannel();
       const producer = new Producer(createFakeConnection(channel));
 
       await producer.createRpcQueue('shutdown:producer-close:listeners:a');
@@ -953,9 +927,8 @@ describe('graceful shutdown', () => {
       assert.strictEqual(channel.listenerCount('close'), 1);
     });
 
-    it('createRpcQueue() stops retrying (does not spin) once getDefaultChannel rejects with ConnectionClosedError', async () => {
-      const channel = createFakeChannelForRpc();
-      const connection = createFakeConnection(channel);
+    it('createRpcQueue() stops retrying once getDefaultChannel rejects with ConnectionClosedError', async () => {
+      const connection = createFakeConnection(createFakeChannel());
       connection.getDefaultChannel = sinon.stub().rejects(new ConnectionClosedError());
       const producer = new Producer(connection);
       const timeoutSpy = sandbox.spy(utils, 'timeoutPromise');
@@ -975,7 +948,7 @@ describe('graceful shutdown', () => {
     // handler below is on checkRpc()'s own promise, a different promise than the deferred, and does
     // not mask this.
     it('a close landing while the RPC publish is still in flight does not leave the rejection unhandled', async () => {
-      const channel = createFakeChannelForRpc();
+      const channel = createFakeChannel();
       const publishGate = pDefer();
       // A publish that is a real round-trip rather than a microtask, so the window is actually open.
       channel.sendToQueue = sinon.stub().callsFake(() => publishGate.promise);
@@ -1008,7 +981,7 @@ describe('graceful shutdown', () => {
     });
 
     it('deletes the waiter when the publish itself fails, so nothing is left in the registry', async () => {
-      const channel = createFakeChannelForRpc();
+      const channel = createFakeChannel();
       channel.sendToQueue = sinon.stub().rejects(new Error('broker blip'));
       const producer = new Producer(createFakeConnection(channel));
       const queue = 'shutdown:producer-close:publish-failed';
@@ -1030,13 +1003,8 @@ describe('graceful shutdown', () => {
     // channel - so a broker that goes away no longer leaves RPC callers hanging out rpcTimeout, or
     // forever with rpcTimeout: 0.
     it('rejects pending RPC waiters when the socket dies on its own, not just on close()', async () => {
-      const connection = new Connection({
-        host: 'amqp://localhost',
-        hostname: 'shutdown-producer-socket-death',
-        prefetch: 5,
-        timeout: 10,
-        rpcTimeout: 0, // no timer is armed at all, so only the listener can settle this
-      });
+      // rpcTimeout: 0 arms no timer at all, so only the channel-close listener can settle this
+      const connection = newConnection({ hostname: 'shutdown-producer-socket-death', rpcTimeout: 0 });
       const mq = new ArnavMQ(connection);
       const queue = 'shutdown:producer-close:socket-death';
       // deliberately unconsumed - only the channel-close listener can ever settle this
@@ -1061,24 +1029,6 @@ describe('graceful shutdown', () => {
   describe('arnavmq.js close() orchestration', () => {
     const sandbox = sinon.createSandbox();
     afterEach(() => sandbox.restore());
-
-    // A fresh, isolated ArnavMQ+Connection pair against the real broker - not the process-wide
-    // singleton every other spec file (including arnavmqConfigurator() calls elsewhere in this
-    // file) shares, since close() is terminal and would otherwise poison every test that runs after.
-    function newArnavmq(overrides = {}) {
-      const conn = new Connection({
-        host: 'amqp://localhost',
-        hostname: 'shutdown-arnavmq-close-test',
-        prefetch: 5,
-        timeout: 10,
-        requeue: true,
-        consumerSuffix: '',
-        producerMaxRetries: -1,
-        rpcTimeout: 0,
-        ...overrides,
-      });
-      return new ArnavMQ(conn);
-    }
 
     describe('the object returned by the top-level factory', () => {
       it('exposes close(), connection.close()/isClosed, and the additive consumer sub-API', () => {
@@ -1124,14 +1074,12 @@ describe('graceful shutdown', () => {
       });
 
       await arnavmq.publish(queue, { n: 1 });
-      await waitFor(() => arnavmq.consumer.inFlight(queue) === 1);
+      await waitFor(() => arnavmq.consumer.inFlight() === 1);
 
       const closePromise = arnavmq.close();
-      await utils.timeoutPromise(100); // give close() time to cancel and start draining
+      await waitForCancelled(arnavmq); // cancelled, now draining
 
       assert.strictEqual(arnavmq.connection.isClosed, false, 'connection must stay open while draining');
-      const [record] = [...arnavmq.consumer._subscriptions.values()];
-      assert.strictEqual(record.cancelled, true, 'expected close() to have cancelled the subscription by now');
       assert.strictEqual(callCount, 1);
 
       gate.resolve();
@@ -1151,7 +1099,7 @@ describe('graceful shutdown', () => {
       });
 
       await arnavmq.publish(queue, { n: 1 });
-      await waitFor(() => arnavmq.consumer.inFlight(queue) === 1);
+      await waitFor(() => arnavmq.consumer.inFlight() === 1);
 
       let closed = false;
       const closePromise = arnavmq.close().then(() => {
@@ -1167,7 +1115,7 @@ describe('graceful shutdown', () => {
       assert.strictEqual(arnavmq.connection.isClosed, true);
     });
 
-    it('calls producer.stop() before connection.close() - produce() during the drain window still succeeds; only fails with ConnectionClosedError once close() fully resolves', async () => {
+    it('a handler can publish during the drain, and publishing only fails once close() has resolved', async () => {
       const arnavmq = newArnavmq();
       const queue = 'shutdown:arnavmq-close:producer-order';
       const sideQueue = 'shutdown:arnavmq-close:producer-order:side';
@@ -1176,26 +1124,21 @@ describe('graceful shutdown', () => {
 
       await arnavmq.subscribe(queue, async () => {
         await proceedGate.promise;
-        try {
-          await arnavmq.publish(sideQueue, { ok: true });
-          publishSettled.resolve({ ok: true });
-        } catch (error) {
-          publishSettled.resolve({ error });
-        }
+        publishSettled.resolve(await settled(() => arnavmq.publish(sideQueue, { ok: true })));
       });
 
       await arnavmq.publish(queue, { n: 1 });
-      await waitFor(() => arnavmq.consumer.inFlight(queue) === 1);
+      await waitFor(() => arnavmq.consumer.inFlight() === 1);
 
       const closePromise = arnavmq.close();
-      await utils.timeoutPromise(50); // close() is now cancelling/draining; the handler is still gated
+      await waitForCancelled(arnavmq); // cancelled, now draining; the handler is still gated
 
       assert.strictEqual(arnavmq.connection.isClosed, false, 'connection must still be open mid-drain');
 
       proceedGate.resolve(); // let the handler publish downstream while the connection is still open
       const publishOutcome = await publishSettled.promise;
 
-      assert.strictEqual(publishOutcome.error, undefined, 'expected produce() during the drain window to succeed');
+      assert(!(publishOutcome instanceof Error), `expected a publish during the drain to succeed: ${publishOutcome}`);
       assert.strictEqual(
         arnavmq.connection.isClosed,
         false,
@@ -1250,10 +1193,10 @@ describe('graceful shutdown', () => {
       });
 
       await arnavmq.publish(queue, { n: 1 });
-      await waitFor(() => arnavmq.consumer.inFlight(queue) === 1);
+      await waitFor(() => arnavmq.consumer.inFlight() === 1);
 
       const closePromise = arnavmq.close();
-      await utils.timeoutPromise(50); // close() has cancelled and is draining; the handler is gated
+      await waitForCancelled(arnavmq); // cancelled, now draining; the handler is gated
       gate.resolve(); // handler finishes and acks
       await closePromise;
 
@@ -1307,7 +1250,7 @@ describe('graceful shutdown', () => {
       // deliberately no consumer subscribed on `queue` - this RPC call never gets answered on its own.
 
       const rpcPromise = arnavmq.publish(queue, { ping: true }, { rpc: true });
-      await utils.timeoutPromise(100); // let checkRpc()/createRpcQueue() register the pending waiter
+      await waitFor(() => !!pendingCorrelationId(arnavmq.producer, queue));
 
       // Attach the rejection expectation *before/alongside* close(), not after awaiting it: the
       // waiter is rejected from the channel-close listener partway through connection.close(),
@@ -1345,7 +1288,7 @@ describe('graceful shutdown', () => {
       await waitFor(() => server.consumer.inFlight() === 1);
 
       const closePromise = server.close();
-      await utils.timeoutPromise(50); // cancelled, now draining; the handler is still gated
+      await waitForCancelled(server); // cancelled, now draining; the handler is still gated
       assert.strictEqual(server.connection.isClosed, false, 'connection must still be open mid-drain');
 
       proceedGate.resolve(); // the handler returns, and checkRpc() writes the reply
@@ -1372,30 +1315,21 @@ describe('graceful shutdown', () => {
       const outcomes = pDefer();
       await app.subscribe(queue, async () => {
         await proceedGate.promise;
-        const result = {};
-        try {
-          await app.publish(sideQueue, { plain: true });
-          result.plain = 'sent';
-        } catch (error) {
-          result.plain = error;
-        }
-        try {
-          result.rpc = await app.publish(rpcQueue, { ping: true }, { rpc: true });
-        } catch (error) {
-          result.rpc = error;
-        }
-        outcomes.resolve(result);
+        outcomes.resolve({
+          plain: await settled(() => app.publish(sideQueue, { plain: true })),
+          rpc: await settled(() => app.publish(rpcQueue, { ping: true }, { rpc: true })),
+        });
       });
 
       await app.publish(queue, { n: 1 });
       await waitFor(() => app.consumer.inFlight() === 1);
 
       const closePromise = app.close();
-      await utils.timeoutPromise(50); // cancelled, now draining; the handler is still gated
+      await waitForCancelled(app); // cancelled, now draining; the handler is still gated
       proceedGate.resolve();
 
       const result = await outcomes.promise;
-      assert.strictEqual(result.plain, 'sent', `expected a plain publish to still succeed, got ${result.plain}`);
+      assert(!(result.plain instanceof Error), `expected a plain publish to still succeed, got ${result.plain}`);
       assert.deepStrictEqual(result.rpc, { pong: true }, `expected the RPC to be answered, got ${result.rpc}`);
 
       await closePromise;

--- a/test/shutdown-spec.js
+++ b/test/shutdown-spec.js
@@ -295,14 +295,26 @@ describe('graceful shutdown', () => {
         );
       });
 
-      it('after stop(), even brand-new subscribe() calls never consume', async () => {
+      // Resolving `false` here (as this used to) let a service that resubscribed after a shutdown
+      // boot "successfully", report healthy and consume nothing for the rest of its life. publish()
+      // already failed loudly on the same state.
+      it('after stop(), subscribe() rejects instead of quietly resolving false', async () => {
         await consumer.stop();
 
         const initSpy = sandbox.spy(consumer, '_initializeChannel');
-        const result = await consumer.subscribe('shutdown:after-cancel-all', () => {});
 
-        assert.strictEqual(result, false);
+        await assert.rejects(() => consumer.subscribe('shutdown:after-cancel-all', () => {}), ConnectionClosedError);
         sinon.assert.notCalled(initSpy);
+      });
+
+      it('rejects a subscribe after the connection itself was closed, without a stop() first', async () => {
+        const isolated = new Consumer(newConnection({ hostname: 'shutdown-subscribe-after-close' }));
+        await isolated.connection.close();
+
+        await assert.rejects(
+          () => isolated.subscribe('shutdown:after-connection-close', () => {}),
+          ConnectionClosedError,
+        );
       });
     });
 
@@ -432,6 +444,60 @@ describe('graceful shutdown', () => {
       });
     });
 
+    // A queue that cannot be declared as asked (PRECONDITION_FAILED from changed arguments,
+    // ACCESS_REFUSED) is answered with a channel-level error, which kills the channel. Consuming on
+    // it afterwards cannot work, so the declaration failing has to be treated as the subscription
+    // failing - not logged and stepped over.
+    describe('a subscription whose setup keeps failing', () => {
+      function newFailingAssertConsumer() {
+        const { channel, connection, consumer } = newTestConsumer({ timeout: 60 });
+        channel.assertQueue = sinon.stub().callsFake(async () => {
+          // what the broker actually does: channel-level error, so the channel dies with it
+          channel.emit('close');
+          throw new Error('PRECONDITION_FAILED - inequivalent arg durable');
+        });
+        return { channel, connection, consumer };
+      }
+
+      it('retries behind the configured backoff instead of once per broker round-trip', async () => {
+        const { connection, consumer } = newFailingAssertConsumer();
+
+        consumer.subscribe('shutdown:setup-failure:backoff', () => {}).catch(() => {});
+        await utils.timeoutPromise(400);
+
+        // ~400ms at a 60ms backoff is a handful of attempts. Unbounded, this opened a fresh channel
+        // per round-trip - measured at ~660/s against a real broker - and two competing retry
+        // loops would instead double every cycle.
+        const attempts = connection.getChannel.callCount;
+        assert(attempts > 1, 'expected it to keep retrying');
+        assert(attempts < 15, `expected the backoff to bound the retries, got ${attempts} channels in 400ms`);
+      });
+
+      it('never resolves true - the subscription is not consuming', async () => {
+        const { consumer } = newFailingAssertConsumer();
+
+        const settled = await Promise.race([
+          consumer.subscribe('shutdown:setup-failure:never-true', () => {}).then((value) => ({ value })),
+          utils.timeoutPromise(300).then(() => 'still-pending'),
+        ]);
+
+        assert.strictEqual(
+          settled,
+          'still-pending',
+          `expected subscribe() to stay pending, it settled: ${JSON.stringify(settled)}`,
+        );
+      });
+
+      it('resolves false when the broker refuses the basic.consume itself', async () => {
+        const { channel, consumer } = newTestConsumer();
+        channel.consume = sinon.stub().rejects(new Error('ACCESS_REFUSED - consume'));
+
+        // Unlike a dead channel there is nothing to retry against here, so the caller is told
+        // plainly rather than the failure being logged and reported as success.
+        assert.strictEqual(await consumer.subscribe('shutdown:setup-failure:consume-refused', () => {}), false);
+      });
+    });
+
     describe('in-flight tracking', () => {
       it('inFlight() brackets both the ack path and the reject path', async () => {
         const { channel, consumer } = newTestConsumer();
@@ -460,6 +526,27 @@ describe('graceful shutdown', () => {
         assert.strictEqual(observedDuringRejectHandler, 1, 'expected inFlight() to be 1 while the handler runs');
         assert.strictEqual(consumer.inFlight(), 0, 'expected inFlight() back to 0 once rejected');
         sinon.assert.calledOnce(channel.reject);
+      });
+
+      it('reports the requeue to the after-process hook, so the delivery is not invisible', async () => {
+        const { channel, consumer } = newTestConsumer();
+        const queue = 'shutdown:inflight:buffered-hook';
+        const payloads = [];
+        consumer.hooks.afterProcessMessage((payload) => payloads.push(payload));
+
+        await consumer.consume(queue, () => 'ok');
+        consumer._subscriptions[0].cancelled = true;
+
+        const msg = fakeMessage({ a: 1 });
+        await deliver(channel, queue, msg);
+
+        // Without this event a caller's received and completed counters silently disagree by every
+        // message the broker had buffered under prefetch when the shutdown started.
+        assert.strictEqual(payloads.length, 1);
+        assert.strictEqual(payloads[0].queue, queue);
+        assert.strictEqual(payloads[0].message, msg);
+        assert.strictEqual(payloads[0].requeued, true);
+        assert.strictEqual(payloads[0].rejectError, undefined);
       });
 
       it('rejects+requeues a buffered message without running the handler once the subscription is no longer live', async () => {

--- a/test/shutdown-spec.js
+++ b/test/shutdown-spec.js
@@ -997,6 +997,41 @@ describe('graceful shutdown', () => {
       );
     });
 
+    // The sweep drops the whole per-queue entry, and checkRpc() has two awaits between creating that
+    // entry and registering its waiter in it. A close landing in between used to leave checkRpc()
+    // indexing a key that was gone, so the caller got a TypeError instead of the publish's own
+    // retryable error - and with retries capped, a real message failed for the wrong reason.
+    it('survives a close landing between createRpcQueue() and the waiter registration', async () => {
+      const channel = createFakeChannel();
+      channel.sendToQueue = sinon.stub().callsFake(() => {
+        throw new Error('Channel closed');
+      });
+      const producer = new Producer(createFakeConnection(channel));
+      const queue = 'shutdown:producer-close:setup-window';
+
+      // drive the close into the window, exactly once
+      const createRpcQueue = producer.createRpcQueue.bind(producer);
+      let dropped = false;
+      producer.createRpcQueue = async (q) => {
+        const resQueue = await createRpcQueue(q);
+        if (!dropped) {
+          dropped = true;
+          channel.emit('close');
+        }
+        return resQueue;
+      };
+
+      await assert.rejects(() => producer.checkRpc(queue, 'payload', { rpc: true }), /Channel closed/);
+
+      // The publish's own error is what the caller must see: unlike ConnectionClosedError it is
+      // retryable, so _sendToQueue reconnects and republishes rather than losing the request.
+      assert.strictEqual(
+        pendingCorrelationId(producer, queue),
+        undefined,
+        'expected no orphaned RPC waiter after the failed publish',
+      );
+    });
+
     // The win from putting this on the channel rather than in close(): the same code covers a
     // connection that died on its own. amqplib routes every teardown through
     // Connection.toClosed() -> _closeChannels() -> Channel.toClosed(), which emits 'close' on every

--- a/test/shutdown-spec.js
+++ b/test/shutdown-spec.js
@@ -528,25 +528,41 @@ describe('graceful shutdown', () => {
         sinon.assert.calledOnce(channel.reject);
       });
 
-      it('reports the requeue to the after-process hook, so the delivery is not invisible', async () => {
+      // Instrumentation starts its span in the before hook and ends whatever the after hook finds,
+      // so emitting only the after event trades one invisible delivery for another: verified
+      // against the real @bringg/instrumentation-arnavmq hooks, after-alone produced no span at all.
+      // Without either, a caller's received and completed counters silently disagree by every
+      // message the broker had buffered under prefetch when the shutdown started.
+      it('emits the before/after hook pair for the requeue, so the delivery is not invisible', async () => {
         const { channel, consumer } = newTestConsumer();
         const queue = 'shutdown:inflight:buffered-hook';
-        const payloads = [];
-        consumer.hooks.afterProcessMessage((payload) => payloads.push(payload));
+        const events = [];
+        const handler = () => 'ok';
+        consumer.hooks.beforeProcessMessage((payload) => events.push(['before', payload]));
+        consumer.hooks.afterProcessMessage((payload) => events.push(['after', payload]));
 
-        await consumer.consume(queue, () => 'ok');
+        await consumer.consume(queue, handler);
         consumer._subscriptions[0].cancelled = true;
 
         const msg = fakeMessage({ a: 1 });
         await deliver(channel, queue, msg);
 
-        // Without this event a caller's received and completed counters silently disagree by every
-        // message the broker had buffered under prefetch when the shutdown started.
-        assert.strictEqual(payloads.length, 1);
-        assert.strictEqual(payloads[0].queue, queue);
-        assert.strictEqual(payloads[0].message, msg);
-        assert.strictEqual(payloads[0].requeued, true);
-        assert.strictEqual(payloads[0].rejectError, undefined);
+        assert.deepStrictEqual(
+          events.map(([name]) => name),
+          ['before', 'after'],
+        );
+
+        const [, before] = events[0];
+        assert.strictEqual(before.queue, queue);
+        assert.strictEqual(before.action.message, msg);
+        assert.strictEqual(before.action.callback, handler);
+        assert.strictEqual(before.action.content, undefined, 'nothing is deserialized on this path');
+
+        const [, after] = events[1];
+        assert.strictEqual(after.queue, queue);
+        assert.strictEqual(after.message, msg);
+        assert.strictEqual(after.requeued, true);
+        assert.strictEqual(after.rejectError, undefined);
       });
 
       it('rejects+requeues a buffered message without running the handler once the subscription is no longer live', async () => {

--- a/test/shutdown-spec.js
+++ b/test/shutdown-spec.js
@@ -207,8 +207,7 @@ describe('graceful shutdown', () => {
           consumerTag: null,
           onChannelClose: null,
           cancelled: false,
-          inFlightMessages: new Set(),
-          abandonedMessages: new Set(),
+          inFlightCount: 0,
         };
 
         await consumer._initializeChannel(record);
@@ -245,7 +244,7 @@ describe('graceful shutdown', () => {
           0,
           'cancelled subscriptions must not leave their resubscribe listener on the shared channel',
         );
-        // ...but the records themselves stay: _abandonInFlightMessages()/inFlight() still read them.
+        // ...but the records themselves stay: inFlight() still reads them.
         assert.strictEqual(consumer._subscriptions.length, 5, 'cancelled records must remain in the registry');
       });
     });
@@ -356,125 +355,84 @@ describe('graceful shutdown', () => {
         assert.strictEqual(consumer.inFlight(rejectQueue), 0, 'expected inFlight() back to 0 once rejected');
         sinon.assert.calledOnce(channel.reject);
       });
-    });
 
-    describe('abandoned-message guards (drain-timeout path)', () => {
-      it('skips ack for an abandoned message and leaves the channel undamaged', async () => {
+      it('rejects+requeues a buffered message without running the handler once the subscription is no longer live', async () => {
         const { channel, consumer } = newTestConsumer();
-        const queue = 'shutdown:guard:ack';
+        const queue = 'shutdown:inflight:buffered-after-cancel';
+        let handlerCalls = 0;
 
-        await consumer.consume(queue, () => 'ok');
+        await consumer.consume(queue, () => {
+          handlerCalls += 1;
+          return 'ok';
+        });
         const record = [...consumer._subscriptions.values()][0];
-        const msg = fakeMessage({ a: 1 });
-        record.abandonedMessages.add(msg);
+        record.cancelled = true; // simulates a delivery buffered before cancel-ok landed
 
-        await deliver(channel, queue, msg);
+        await deliver(channel, queue, fakeMessage({ a: 1 }));
 
+        assert.strictEqual(handlerCalls, 0, 'the handler must not run for a message delivered after cancel');
+        assert.strictEqual(consumer.inFlight(queue), 0);
+        sinon.assert.calledOnce(channel.reject);
+        sinon.assert.calledWith(channel.reject, sinon.match.any, true);
         sinon.assert.notCalled(channel.ack);
-        sinon.assert.notCalled(channel.close);
-      });
-
-      it('skips reject for an abandoned message on the handler-error path and leaves the channel undamaged', async () => {
-        const { channel, consumer } = newTestConsumer();
-        const queue = 'shutdown:guard:reject';
-
-        await consumer.consume(queue, () => {
-          throw new Error('boom');
-        });
-        const record = [...consumer._subscriptions.values()][0];
-        const msg = fakeMessage({ a: 1 });
-        record.abandonedMessages.add(msg);
-
-        await deliver(channel, queue, msg);
-
-        sinon.assert.notCalled(channel.reject);
-        sinon.assert.notCalled(channel.close);
-      });
-
-      it('skips the RPC reply for an abandoned message on the success path', async () => {
-        const { channel, consumer } = newTestConsumer();
-        const queue = 'shutdown:guard:rpc-success';
-
-        await consumer.consume(queue, () => 'ok');
-        const record = [...consumer._subscriptions.values()][0];
-        const msg = fakeMessage({ a: 1 }, { replyTo: 'reply-queue', correlationId: 'abc' });
-        record.abandonedMessages.add(msg);
-
-        await deliver(channel, queue, msg);
-
-        sinon.assert.notCalled(channel.sendToQueue);
-        sinon.assert.notCalled(channel.close);
-      });
-
-      it('skips the RPC reply for an abandoned message on the non-requeue reject path', async () => {
-        const { channel, consumer } = newTestConsumer({ requeue: false });
-        const queue = 'shutdown:guard:rpc-reject';
-
-        await consumer.consume(queue, () => {
-          throw new Error('boom');
-        });
-        const record = [...consumer._subscriptions.values()][0];
-        const msg = fakeMessage({ a: 1 }, { replyTo: 'reply-queue', correlationId: 'abc' });
-        record.abandonedMessages.add(msg);
-
-        await deliver(channel, queue, msg);
-
-        sinon.assert.notCalled(channel.reject);
-        sinon.assert.notCalled(channel.sendToQueue);
-        sinon.assert.notCalled(channel.close);
       });
     });
 
     describe('drain()', () => {
-      it('resolves true immediately when nothing is in flight', async () => {
-        const { channel, consumer } = newTestConsumer();
+      it('resolves immediately when nothing is in flight', async () => {
+        const { consumer } = newTestConsumer();
         await consumer.consume('shutdown:drain:empty', () => 'ok');
 
-        assert.strictEqual(await consumer.drain(1000), true);
+        await consumer.drain();
       });
 
-      it('resolves true once the in-flight handler finishes, and cancels nothing', async () => {
+      it('resolves once the in-flight handler finishes, and cancels nothing', async () => {
         const { channel, consumer } = newTestConsumer();
-        const queue = 'shutdown:drain:waits-then-true';
+        const queue = 'shutdown:drain:waits-then-resolves';
         const handlerDefer = pDefer();
 
         await consumer.consume(queue, () => handlerDefer.promise);
         const deliverPromise = deliver(channel, queue, fakeMessage({ a: 1 }));
 
         assert.strictEqual(consumer.inFlight(queue), 1);
-        const drainPromise = consumer.drain(1000);
+        const drainPromise = consumer.drain();
 
         handlerDefer.resolve('ok');
         await deliverPromise;
 
-        assert.strictEqual(await drainPromise, true);
+        await drainPromise;
         sinon.assert.notCalled(channel.cancel);
       });
 
-      it('resolves false when the in-flight handler does not finish before the timeout', async () => {
+      it('does not resolve while a handler is still running', async () => {
         const { channel, consumer } = newTestConsumer();
-        const queue = 'shutdown:drain:times-out';
+        const queue = 'shutdown:drain:waits-indefinitely';
         const handlerDefer = pDefer();
 
         await consumer.consume(queue, () => handlerDefer.promise);
         const deliverPromise = deliver(channel, queue, fakeMessage({ a: 1 }));
 
-        assert.strictEqual(await consumer.drain(120), false);
+        let drained = false;
+        consumer.drain().then(() => {
+          drained = true;
+        });
 
-        // let the still-running handler finish so it doesn't leak into the next test
+        await utils.timeoutPromise(150);
+        assert.strictEqual(drained, false, 'expected drain() to still be waiting on the in-flight handler');
+
         handlerDefer.resolve('ok');
         await deliverPromise;
       });
     });
 
     describe('stop()', () => {
-      it('cancels every subscription then reports a clean drain with nothing abandoned', async () => {
+      it('cancels every subscription then resolves once nothing is in flight', async () => {
         const { channel, consumer } = newTestConsumer();
         const queue = 'shutdown:stop:clean';
 
         await consumer.consume(queue, () => 'ok');
 
-        assert.deepStrictEqual(await consumer.stop({ timeout: 1000 }), { drained: true, abandoned: {} });
+        await consumer.stop();
         sinon.assert.called(channel.cancel);
         sinon.assert.notCalled(channel.close);
         assert.strictEqual(consumer._shuttingDown, true);
@@ -484,66 +442,34 @@ describe('graceful shutdown', () => {
         const { channel, consumer } = newTestConsumer();
         await consumer.consume('shutdown:stop:idempotent', () => 'ok');
 
-        const [first, second] = await Promise.all([consumer.stop(), consumer.stop()]);
+        await Promise.all([consumer.stop(), consumer.stop()]);
 
-        assert.deepStrictEqual(first, { drained: true, abandoned: {} });
-        assert.strictEqual(second, first, 'both calls must resolve with the one memoized shutdown result');
         sinon.assert.calledOnce(channel.cancel);
       });
 
-      it("on timeout, rejects+requeues abandoned in-flight messages and guards the handler's own ack afterward", async () => {
+      it('waits out a slow handler rather than abandoning it', async () => {
         const { channel, consumer } = newTestConsumer();
-        const queue = 'shutdown:stop:timeout-abandons';
+        const queue = 'shutdown:stop:waits-for-slow-handler';
         const handlerDefer = pDefer();
 
         await consumer.consume(queue, () => handlerDefer.promise);
         const deliverPromise = deliver(channel, queue, fakeMessage({ a: 1 }));
 
-        const stopped = await consumer.stop({ timeout: 120 });
-        assert.deepStrictEqual(stopped, { drained: false, abandoned: { [queue]: 1 } });
+        let stopped = false;
+        const stopPromise = consumer.stop().then(() => {
+          stopped = true;
+        });
 
-        sinon.assert.calledOnce(channel.reject);
-        sinon.assert.calledWith(channel.reject, sinon.match.any, true);
-        sinon.assert.notCalled(channel.close);
+        await utils.timeoutPromise(150);
+        assert.strictEqual(stopped, false, 'expected stop() to still be waiting on the in-flight handler');
+        sinon.assert.notCalled(channel.reject);
 
-        // the handler is not killed - it keeps running and eventually resolves; its own completion
-        // must not double-ack/double-reject/double-reply on a delivery already abandoned above.
         handlerDefer.resolve('ok');
         await deliverPromise;
+        await stopPromise;
 
-        sinon.assert.notCalled(channel.ack);
-        sinon.assert.calledOnce(channel.reject);
-        sinon.assert.notCalled(channel.close);
-      });
-
-      // The per-queue abandoned count is returned to the caller, who turns it into a metric - it has
-      // to be accurate and scoped per queue rather than aggregated.
-      it('reports the abandoned-message count per queue - only the queue that timed out appears in the map', async () => {
-        const { channel, consumer } = newTestConsumer();
-        const cleanQueue = 'shutdown:stop:abandoned-map:clean';
-        const stuckQueue = 'shutdown:stop:abandoned-map:stuck';
-        const handlerDefer = pDefer();
-
-        await consumer.consume(cleanQueue, () => 'ok');
-        await consumer.consume(stuckQueue, () => handlerDefer.promise);
-
-        // one message drains cleanly on cleanQueue before stop() is even called...
-        await deliver(channel, cleanQueue, fakeMessage({ a: 1 }));
-        // ...while two are stuck in the never-resolving handler on stuckQueue.
-        const stuckDeliveries = [
-          deliver(channel, stuckQueue, fakeMessage({ b: 1 })),
-          deliver(channel, stuckQueue, fakeMessage({ b: 2 })),
-        ];
-        assert.strictEqual(consumer.inFlight(stuckQueue), 2);
-
-        const result = await consumer.stop({ timeout: 120 });
-
-        assert.deepStrictEqual(result, { drained: false, abandoned: { [stuckQueue]: 2 } });
-        assert.strictEqual(channel.reject.callCount, 2, 'expected exactly the two stuck messages to be requeued');
-
-        // let the still-running handler finish so it doesn't leak into the next test
-        handlerDefer.resolve('ok');
-        await Promise.all(stuckDeliveries);
+        sinon.assert.calledOnce(channel.ack);
+        sinon.assert.notCalled(channel.reject);
       });
     });
 
@@ -1004,7 +930,6 @@ describe('graceful shutdown', () => {
         consumerSuffix: '',
         producerMaxRetries: -1,
         rpcTimeout: 0,
-        shutdownTimeout: 5000,
         ...overrides,
       });
       return new ArnavMQ(conn);
@@ -1061,7 +986,7 @@ describe('graceful shutdown', () => {
       await arnavmq.publish(queue, { n: 1 });
       await waitFor(() => arnavmq.consumer.inFlight(queue) === 1);
 
-      const closePromise = arnavmq.close({ timeout: 5000 });
+      const closePromise = arnavmq.close();
       await utils.timeoutPromise(100); // give close() time to cancel and start draining
 
       assert.strictEqual(arnavmq.connection.isClosed, false, 'connection must stay open while draining');
@@ -1070,16 +995,15 @@ describe('graceful shutdown', () => {
       assert.strictEqual(callCount, 1);
 
       gate.resolve();
-      assert.deepStrictEqual(await closePromise, { drained: true, abandoned: {} });
+      assert.strictEqual(await closePromise, undefined);
 
       assert.strictEqual(callCount, 1, 'the cancelled subscription must not receive a second delivery');
-      assert.strictEqual(record.abandonedMessages.size, 0, 'the message drained cleanly, nothing should be abandoned');
       assert.strictEqual(arnavmq.connection.isClosed, true);
     });
 
-    it('rejects+requeues an in-flight message when the handler outlives the drain timeout', async () => {
+    it('does not resolve while an in-flight handler is still running, and waits for it rather than abandoning it', async () => {
       const arnavmq = newArnavmq();
-      const queue = 'shutdown:arnavmq-close:timeout-reject';
+      const queue = 'shutdown:arnavmq-close:waits-for-slow-handler';
       const gate = pDefer();
 
       await arnavmq.subscribe(queue, async () => {
@@ -1089,16 +1013,18 @@ describe('graceful shutdown', () => {
       await arnavmq.publish(queue, { n: 1 });
       await waitFor(() => arnavmq.consumer.inFlight(queue) === 1);
 
-      const result = await arnavmq.close({ timeout: 100 });
+      let closed = false;
+      const closePromise = arnavmq.close().then(() => {
+        closed = true;
+      });
 
-      // keyed by queue name, so a caller can emit an abandoned-message metric off it.
-      assert.deepStrictEqual(result, { drained: false, abandoned: { [queue]: 1 } });
-      assert.strictEqual(arnavmq.connection.isClosed, true);
-      const [record] = [...arnavmq.consumer._subscriptions.values()];
-      assert.strictEqual(record.abandonedMessages.size, 1, 'expected the leftover message to be abandoned+requeued');
+      await utils.timeoutPromise(150);
+      assert.strictEqual(closed, false, 'expected close() to still be waiting on the in-flight handler');
+      assert.strictEqual(arnavmq.connection.isClosed, false);
 
-      // let the still-running handler finish so it doesn't leak into later tests
       gate.resolve();
+      await closePromise;
+      assert.strictEqual(arnavmq.connection.isClosed, true);
     });
 
     it('calls producer.stop() before connection.close() - produce() during the drain window still succeeds; only fails with ConnectionClosedError once close() fully resolves', async () => {
@@ -1121,7 +1047,7 @@ describe('graceful shutdown', () => {
       await arnavmq.publish(queue, { n: 1 });
       await waitFor(() => arnavmq.consumer.inFlight(queue) === 1);
 
-      const closePromise = arnavmq.close({ timeout: 5000 });
+      const closePromise = arnavmq.close();
       await utils.timeoutPromise(50); // close() is now cancelling/draining; the handler is still gated
 
       assert.strictEqual(arnavmq.connection.isClosed, false, 'connection must still be open mid-drain');
@@ -1186,18 +1112,12 @@ describe('graceful shutdown', () => {
       await arnavmq.publish(queue, { n: 1 });
       await waitFor(() => arnavmq.consumer.inFlight(queue) === 1);
 
-      const closePromise = arnavmq.close({ timeout: 5000 });
+      const closePromise = arnavmq.close();
       await utils.timeoutPromise(50); // close() has cancelled and is draining; the handler is gated
-      gate.resolve(); // handler finishes and acks well inside the 5s drain budget
+      gate.resolve(); // handler finishes and acks
       await closePromise;
 
-      const [record] = [...arnavmq.consumer._subscriptions.values()];
       assert.strictEqual(callCount, 1);
-      assert.strictEqual(
-        record.abandonedMessages.size,
-        0,
-        'expected a clean drain (nothing abandoned/rejected) - this test is about the acked path',
-      );
       assert.strictEqual(arnavmq.connection.isClosed, true);
 
       // The actual proof, from outside the closed instance: an independent ArnavMQ+Connection pair on
@@ -1217,42 +1137,6 @@ describe('graceful shutdown', () => {
         `expected the acked message to be gone for good, but it was redelivered: ${JSON.stringify(redelivered)}`,
       );
 
-      await fresh.close();
-    });
-
-    it('close({ timeout }) on a handler that outlives it resolves quickly, and a fresh instance receives the rejected+requeued message', async () => {
-      const arnavmq = newArnavmq();
-      const queue = 'shutdown:arnavmq-close:timeout-reject-redelivered';
-      const gate = pDefer(); // deliberately never resolved here - simulates the 5s+ handler that outlives the drain timeout
-
-      await arnavmq.subscribe(queue, async () => {
-        await gate.promise;
-      });
-
-      await arnavmq.publish(queue, { n: 1 });
-      await waitFor(() => arnavmq.consumer.inFlight(queue) === 1);
-
-      const start = Date.now();
-      await arnavmq.close({ timeout: 100 });
-      const elapsed = Date.now() - start;
-
-      assert(elapsed < 2000, `expected close({ timeout: 100 }) to resolve in ~100ms, took ${elapsed}ms`);
-      assert.strictEqual(arnavmq.connection.isClosed, true);
-
-      const fresh = newArnavmq();
-      const receivedDefer = pDefer();
-      let received;
-      await fresh.subscribe(queue, (body) => {
-        received = body;
-        receivedDefer.resolve();
-      });
-
-      // resolves once the requeued message is actually redelivered to this independent consumer;
-      // if it were lost instead of requeued, this hangs until mocha's suite timeout fails the test.
-      await receivedDefer.promise;
-      assert.strictEqual(received.n, 1);
-
-      gate.resolve(); // let the first instance's still-running handler finish so it doesn't leak
       await fresh.close();
     });
 

--- a/test/shutdown-spec.js
+++ b/test/shutdown-spec.js
@@ -39,6 +39,14 @@ function createFakeConnection(channel, overrides = {}) {
   };
 }
 
+/** A fake channel + connection + Consumer wired together, for tests that don't need the broker. */
+function newTestConsumer(overrides = {}) {
+  const channel = createFakeChannel();
+  const connection = createFakeConnection(channel, overrides);
+  const consumer = new Consumer(connection);
+  return { channel, connection, consumer };
+}
+
 function fakeMessage(content, properties = {}) {
   return {
     content: Buffer.from(JSON.stringify(content)),
@@ -51,6 +59,16 @@ function deliver(channel, queue, msg) {
   const fn = channel.consumeFns.get(queue);
   assert(fn, `no consume callback captured for queue "${queue}" - was consume() awaited first?`);
   return fn(msg);
+}
+
+/** A fake amqp.node channel good enough to drive producer.js's RPC path without a broker. */
+function createFakeChannelForRpc() {
+  const channel = new EventEmitter();
+  channel.assertQueue = sinon.stub().resolves({});
+  channel.consume = sinon.stub().resolves({ consumerTag: 'fake-tag' });
+  channel.sendToQueue = sinon.stub().returns(true);
+  channel.publish = sinon.stub().returns(true);
+  return channel;
 }
 
 describe('graceful shutdown', () => {
@@ -144,7 +162,7 @@ describe('graceful shutdown', () => {
         assert.strictEqual(await subscribePromise, false);
       });
 
-      it('stops the retry loop once cancelled, without ever consuming', async () => {
+      it("subscribe()'s retry loop stops once cancelled, without ever consuming", async () => {
         const queue = 'shutdown:retry:stop-on-cancel';
         arnavmqConfigurator({ timeout: 20 });
         const initStub = sandbox.stub(consumer, '_initializeChannel').resolves(null);
@@ -179,9 +197,7 @@ describe('graceful shutdown', () => {
 
     describe('listener hygiene on the shared channel', () => {
       it('does not accumulate close listeners across repeated _initializeChannel calls for one record', async () => {
-        const sharedChannel = createFakeChannel();
-        const connection = createFakeConnection(sharedChannel);
-        const consumer = new Consumer(connection);
+        const { channel: sharedChannel, consumer } = newTestConsumer();
         const record = {
           id: 1,
           queue: 'shared-channel-queue',
@@ -203,9 +219,7 @@ describe('graceful shutdown', () => {
       });
 
       it('the resubscribe-on-close listener is a no-op once shutting down / cancelled', async () => {
-        const sharedChannel = createFakeChannel();
-        const connection = createFakeConnection(sharedChannel);
-        const consumer = new Consumer(connection);
+        const { channel: sharedChannel, consumer } = newTestConsumer();
 
         await consumer.consume('shutdown:onclose:guard', () => {});
         const record = [...consumer._subscriptions.values()][0];
@@ -218,9 +232,7 @@ describe('graceful shutdown', () => {
       });
 
       it('_cancelSubscription removes the record close listener, so repeated subscribe->cancel cycles do not leak listeners', async () => {
-        const sharedChannel = createFakeChannel();
-        const connection = createFakeConnection(sharedChannel);
-        const consumer = new Consumer(connection);
+        const { channel: sharedChannel, consumer } = newTestConsumer();
         const queue = 'shutdown:cancel:listener-hygiene';
 
         for (let i = 0; i < 5; i += 1) {
@@ -243,12 +255,9 @@ describe('graceful shutdown', () => {
     // window must be re-checked once the tag arrives, or the subscription goes live anyway.
     describe('cancel() landing mid-subscribe (before consumerTag exists)', () => {
       it('cancels the subscription on the broker once its tag arrives - two consume()s on one queue, the second cancelled mid-flight', async () => {
-        const channel = createFakeChannel();
-        const connection = createFakeConnection(channel);
-        const consumer = new Consumer(connection);
+        const { channel, consumer } = newTestConsumer();
         const queue = 'shutdown:cancel:mid-flight';
 
-        // First subscription on the queue goes live normally.
         await consumer.consume(queue, () => {});
         const [first] = [...consumer._subscriptions.values()];
         assert(first.consumerTag, 'expected the first subscription to be fully subscribed');
@@ -290,9 +299,7 @@ describe('graceful shutdown', () => {
       });
 
       it('skips the basic.consume round-trip entirely when the cancel lands before it (mid-assertQueue)', async () => {
-        const channel = createFakeChannel();
-        const connection = createFakeConnection(channel);
-        const consumer = new Consumer(connection);
+        const { channel, consumer } = newTestConsumer();
         const queue = 'shutdown:cancel:mid-assert-queue';
 
         const assertGate = pDefer();
@@ -321,10 +328,8 @@ describe('graceful shutdown', () => {
     });
 
     describe('in-flight tracking', () => {
-      it('brackets both the ack path and the reject path', async () => {
-        const channel = createFakeChannel();
-        const connection = createFakeConnection(channel);
-        const consumer = new Consumer(connection);
+      it('inFlight() brackets both the ack path and the reject path', async () => {
+        const { channel, consumer } = newTestConsumer();
 
         const ackQueue = 'shutdown:inflight:ack-path';
         let observedDuringAckHandler = null;
@@ -355,9 +360,7 @@ describe('graceful shutdown', () => {
 
     describe('abandoned-message guards (drain-timeout path)', () => {
       it('skips ack for an abandoned message and leaves the channel undamaged', async () => {
-        const channel = createFakeChannel();
-        const connection = createFakeConnection(channel);
-        const consumer = new Consumer(connection);
+        const { channel, consumer } = newTestConsumer();
         const queue = 'shutdown:guard:ack';
 
         await consumer.consume(queue, () => 'ok');
@@ -372,9 +375,7 @@ describe('graceful shutdown', () => {
       });
 
       it('skips reject for an abandoned message on the handler-error path and leaves the channel undamaged', async () => {
-        const channel = createFakeChannel();
-        const connection = createFakeConnection(channel);
-        const consumer = new Consumer(connection);
+        const { channel, consumer } = newTestConsumer();
         const queue = 'shutdown:guard:reject';
 
         await consumer.consume(queue, () => {
@@ -391,9 +392,7 @@ describe('graceful shutdown', () => {
       });
 
       it('skips the RPC reply for an abandoned message on the success path', async () => {
-        const channel = createFakeChannel();
-        const connection = createFakeConnection(channel);
-        const consumer = new Consumer(connection);
+        const { channel, consumer } = newTestConsumer();
         const queue = 'shutdown:guard:rpc-success';
 
         await consumer.consume(queue, () => 'ok');
@@ -408,9 +407,7 @@ describe('graceful shutdown', () => {
       });
 
       it('skips the RPC reply for an abandoned message on the non-requeue reject path', async () => {
-        const channel = createFakeChannel();
-        const connection = createFakeConnection(channel, { requeue: false });
-        const consumer = new Consumer(connection);
+        const { channel, consumer } = newTestConsumer({ requeue: false });
         const queue = 'shutdown:guard:rpc-reject';
 
         await consumer.consume(queue, () => {
@@ -430,18 +427,14 @@ describe('graceful shutdown', () => {
 
     describe('drain()', () => {
       it('resolves true immediately when nothing is in flight', async () => {
-        const channel = createFakeChannel();
-        const connection = createFakeConnection(channel);
-        const consumer = new Consumer(connection);
+        const { channel, consumer } = newTestConsumer();
         await consumer.consume('shutdown:drain:empty', () => 'ok');
 
         assert.strictEqual(await consumer.drain(1000), true);
       });
 
       it('resolves true once the in-flight handler finishes, and cancels nothing', async () => {
-        const channel = createFakeChannel();
-        const connection = createFakeConnection(channel);
-        const consumer = new Consumer(connection);
+        const { channel, consumer } = newTestConsumer();
         const queue = 'shutdown:drain:waits-then-true';
         const handlerDefer = pDefer();
 
@@ -459,9 +452,7 @@ describe('graceful shutdown', () => {
       });
 
       it('resolves false when the in-flight handler does not finish before the timeout', async () => {
-        const channel = createFakeChannel();
-        const connection = createFakeConnection(channel);
-        const consumer = new Consumer(connection);
+        const { channel, consumer } = newTestConsumer();
         const queue = 'shutdown:drain:times-out';
         const handlerDefer = pDefer();
 
@@ -478,9 +469,7 @@ describe('graceful shutdown', () => {
 
     describe('stop()', () => {
       it('cancels every subscription then reports a clean drain with nothing abandoned', async () => {
-        const channel = createFakeChannel();
-        const connection = createFakeConnection(channel);
-        const consumer = new Consumer(connection);
+        const { channel, consumer } = newTestConsumer();
         const queue = 'shutdown:stop:clean';
 
         await consumer.consume(queue, () => 'ok');
@@ -492,9 +481,7 @@ describe('graceful shutdown', () => {
       });
 
       it('is idempotent - concurrent calls share one in-flight shutdown', async () => {
-        const channel = createFakeChannel();
-        const connection = createFakeConnection(channel);
-        const consumer = new Consumer(connection);
+        const { channel, consumer } = newTestConsumer();
         await consumer.consume('shutdown:stop:idempotent', () => 'ok');
 
         const [first, second] = await Promise.all([consumer.stop(), consumer.stop()]);
@@ -505,9 +492,7 @@ describe('graceful shutdown', () => {
       });
 
       it("on timeout, rejects+requeues abandoned in-flight messages and guards the handler's own ack afterward", async () => {
-        const channel = createFakeChannel();
-        const connection = createFakeConnection(channel);
-        const consumer = new Consumer(connection);
+        const { channel, consumer } = newTestConsumer();
         const queue = 'shutdown:stop:timeout-abandons';
         const handlerDefer = pDefer();
 
@@ -534,9 +519,7 @@ describe('graceful shutdown', () => {
       // The per-queue abandoned count is returned to the caller, who turns it into a metric - it has
       // to be accurate and scoped per queue rather than aggregated.
       it('reports the abandoned-message count per queue - only the queue that timed out appears in the map', async () => {
-        const channel = createFakeChannel();
-        const connection = createFakeConnection(channel);
-        const consumer = new Consumer(connection);
+        const { channel, consumer } = newTestConsumer();
         const cleanQueue = 'shutdown:stop:abandoned-map:clean';
         const stuckQueue = 'shutdown:stop:abandoned-map:stuck';
         const handlerDefer = pDefer();
@@ -565,10 +548,8 @@ describe('graceful shutdown', () => {
     });
 
     describe('inFlight()', () => {
-      it('counts across all queues', async () => {
-        const channel = createFakeChannel();
-        const connection = createFakeConnection(channel);
-        const consumer = new Consumer(connection);
+      it('inFlight() counts across all queues', async () => {
+        const { channel, consumer } = newTestConsumer();
         const queueA = 'shutdown:inflight:scope-a';
         const queueB = 'shutdown:inflight:scope-b';
         const deferA = pDefer();
@@ -850,13 +831,6 @@ describe('graceful shutdown', () => {
     const sandbox = sinon.createSandbox();
     afterEach(() => sandbox.restore());
 
-    function createFakeChannelForRpc() {
-      const channel = new EventEmitter();
-      channel.assertQueue = sinon.stub().resolves({});
-      channel.consume = sinon.stub().resolves({ consumerTag: 'fake-tag' });
-      return channel;
-    }
-
     /** A fake connection whose 'close' listeners are driven by a real EventEmitter, like the amqp one. */
     function createFakeConnectionWithCloseEvent(channel) {
       const emitter = new EventEmitter();
@@ -919,15 +893,6 @@ describe('graceful shutdown', () => {
   describe('producer.js stop()', () => {
     const sandbox = sinon.createSandbox();
     afterEach(() => sandbox.restore());
-
-    function createFakeChannelForRpc() {
-      const channel = new EventEmitter();
-      channel.assertQueue = sinon.stub().resolves({});
-      channel.consume = sinon.stub().resolves({ consumerTag: 'fake-tag' });
-      channel.sendToQueue = sinon.stub().returns(true);
-      channel.publish = sinon.stub().returns(true);
-      return channel;
-    }
 
     function createFakeConnection(channel, overrides = {}) {
       return {
@@ -1105,7 +1070,6 @@ describe('graceful shutdown', () => {
       assert.strictEqual(callCount, 1);
 
       gate.resolve();
-      // close() reports the drain outcome back to the caller (finding #2): a clean drain, nothing abandoned.
       assert.deepStrictEqual(await closePromise, { drained: true, abandoned: {} });
 
       assert.strictEqual(callCount, 1, 'the cancelled subscription must not receive a second delivery');
@@ -1127,8 +1091,7 @@ describe('graceful shutdown', () => {
 
       const result = await arnavmq.close({ timeout: 100 });
 
-      // close() reports the drain outcome back to the caller (finding #2), keyed by queue name, so a
-      // caller can emit an abandoned-message metric off it.
+      // keyed by queue name, so a caller can emit an abandoned-message metric off it.
       assert.deepStrictEqual(result, { drained: false, abandoned: { [queue]: 1 } });
       assert.strictEqual(arnavmq.connection.isClosed, true);
       const [record] = [...arnavmq.consumer._subscriptions.values()];

--- a/test/shutdown-spec.js
+++ b/test/shutdown-spec.js
@@ -751,6 +751,45 @@ describe('graceful shutdown', () => {
         await assert.rejects(() => conn.getChannel('any-queue', {}), ConnectionClosedError);
       });
     });
+
+    describe('close() landing between getConnection() and the channel-cache check', () => {
+      // getChannel()/getDefaultChannel() each do `await getConnection()` then touch `_channels`.
+      // close() can run entirely inside that gap: it flips `isClosed` synchronously, snapshots and
+      // clears the channel cache in closeAll(), and closes the socket. Without a re-check of
+      // isClosed right after getConnection() resolves, the resumed call would insert a brand new
+      // channel into the (now-cleared) cache that closeAll() already walked past - a channel never
+      // protected by the Channel.Close-Ok barrier, escaping into a connection that's tearing down.
+      function driveCloseIntoTheGap(conn) {
+        const originalGetConnection = conn.getConnection.bind(conn);
+        sandbox.stub(conn, 'getConnection').callsFake(async () => {
+          const result = await originalGetConnection();
+          await conn.close();
+          return result;
+        });
+      }
+
+      it('getChannel() rejects with ConnectionClosedError instead of creating an orphan channel', async () => {
+        const conn = newConnection();
+        const amqpConnection = await conn.getConnection();
+        const createChannelSpy = sandbox.spy(amqpConnection, 'createChannel');
+
+        driveCloseIntoTheGap(conn);
+
+        await assert.rejects(() => conn.getChannel('some-queue', {}), ConnectionClosedError);
+        sinon.assert.notCalled(createChannelSpy);
+      });
+
+      it('getDefaultChannel() rejects with ConnectionClosedError instead of creating an orphan channel', async () => {
+        const conn = newConnection();
+        const amqpConnection = await conn.getConnection();
+        const createChannelSpy = sandbox.spy(amqpConnection, 'createChannel');
+
+        driveCloseIntoTheGap(conn);
+
+        await assert.rejects(() => conn.getDefaultChannel(), ConnectionClosedError);
+        sinon.assert.notCalled(createChannelSpy);
+      });
+    });
   });
 
   describe('producer.js reconnect-on-close guard', () => {

--- a/test/shutdown-spec.js
+++ b/test/shutdown-spec.js
@@ -81,6 +81,53 @@ function createFakeChannelForRpc() {
   return channel;
 }
 
+/** Polls `predicate` every 20ms until truthy, or throws once `timeoutMs` elapses. */
+async function waitFor(predicate, timeoutMs = 3000) {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) {
+      throw new Error('waitFor() timed out');
+    }
+    await utils.timeoutPromise(20);
+  }
+}
+
+/**
+ * Resolves after one full turn of the event loop. Node reports unhandled rejections once the
+ * microtask queue has drained, so draining microtasks alone (`await Promise.resolve()`, however
+ * many times) never observes one, while a single turn always does - making this exact rather than
+ * a sleep long enough to probably work. A sleep that turned out to be too short would report "no
+ * unhandled rejection" and pass a test that should have failed.
+ */
+function nextTurn() {
+  return new Promise((resolve) => {
+    setImmediate(resolve);
+  });
+}
+
+/**
+ * Runs `fn` with every existing 'unhandledRejection' listener (mocha installs one that fails the
+ * current test from underneath it) swapped out for a recorder, and returns what Node reported.
+ * Lets a test assert on unhandled rejections itself, with its own message.
+ */
+async function recordUnhandledRejections(fn) {
+  const existing = process.listeners('unhandledRejection');
+  existing.forEach((listener) => process.removeListener('unhandledRejection', listener));
+
+  const seen = [];
+  const recorder = (error) => seen.push(error);
+  process.on('unhandledRejection', recorder);
+  try {
+    await fn();
+    await nextTurn(); // let Node report anything still unhandled
+  } finally {
+    process.removeListener('unhandledRejection', recorder);
+    existing.forEach((listener) => process.on('unhandledRejection', listener));
+  }
+
+  return seen;
+}
+
 describe('graceful shutdown', () => {
   describe('subscription registry (consumer.js)', () => {
     const sandbox = sinon.createSandbox();
@@ -964,10 +1011,80 @@ describe('graceful shutdown', () => {
         'expected resQueuePromise to still be present after stop()',
       );
     });
+
+    // checkRpc() registers the waiter *before* awaiting the publish and only attaches its own
+    // handler (`return await responsePromise.promise`) after it. A stop() landing in that window -
+    // which is exactly when close() now calls it - rejects a deferred nobody is listening to yet,
+    // and a rejection left unhandled for a full turn of the loop is fatal under Node's default
+    // `--unhandled-rejections=throw`: the process dies during the graceful shutdown that rejected
+    // it. Note the `settled` handler below is on checkRpc()'s own promise, which is a different
+    // promise than the deferred and does not mask this.
+    it('stop() landing while the RPC publish is still in flight does not leave the rejection unhandled', async () => {
+      const channel = createFakeChannelForRpc();
+      const publishGate = pDefer();
+      // A publish that is a real round-trip rather than a microtask, so the window is actually open.
+      channel.sendToQueue = sinon.stub().callsFake(() => publishGate.promise);
+      const connection = createFakeConnection(channel);
+      const producer = new Producer(connection);
+      const queue = 'shutdown:producer-stop:publish-window';
+
+      let settled;
+      const seen = await recordUnhandledRejections(async () => {
+        const rpcPromise = producer.checkRpc(queue, 'payload', { rpc: true });
+        settled = rpcPromise.then(
+          () => undefined,
+          (error) => error,
+        );
+
+        // wait on the actual condition rather than a duration: the waiter is registered and the
+        // publish is in flight exactly once sendToQueue has been called.
+        await waitFor(() => channel.sendToQueue.called);
+        assert(pendingCorrelationId(producer, queue), 'expected the waiter to be registered');
+
+        producer.stop();
+        await nextTurn(); // the turn in which Node would report the rejection as unhandled
+
+        publishGate.resolve(true); // now let the publish finish, so checkRpc() reaches its await
+      });
+
+      assert.deepStrictEqual(
+        seen.map((error) => error && error.message),
+        [],
+        'expected no unhandled rejection while stop() raced the in-flight publish',
+      );
+      assert((await settled) instanceof ConnectionClosedError, 'expected the rejection to still reach the caller');
+    });
+
+    it('deletes the waiter when the publish itself fails, so no orphan is left for a later stop()', async () => {
+      const channel = createFakeChannelForRpc();
+      channel.sendToQueue = sinon.stub().rejects(new Error('broker blip'));
+      const connection = createFakeConnection(channel);
+      const producer = new Producer(connection);
+      const queue = 'shutdown:producer-stop:publish-failed';
+
+      await assert.rejects(() => producer.checkRpc(queue, 'payload', { rpc: true }), /broker blip/);
+
+      // Left behind, the entry can never be settled - prepareTimeoutRpc() was never reached, so it
+      // has no timer - and a stop() minutes later would reject it with no handler attached at all.
+      assert.strictEqual(
+        pendingCorrelationId(producer, queue),
+        undefined,
+        'expected no orphaned RPC waiter after a failed publish',
+      );
+
+      const seen = await recordUnhandledRejections(async () => {
+        producer.stop();
+      });
+      assert.deepStrictEqual(
+        seen.map((error) => error && error.message),
+        [],
+        'expected no orphan to reject',
+      );
+    });
   });
 
-  // src/modules/arnavmq.js's top-level close() orchestrates, in order: cancel -> drain (reject-pass
-  // on timeout) -> producer.stop() -> connection.close().
+  // src/modules/arnavmq.js's top-level close() orchestrates, in order: producer.stop() -> cancel ->
+  // drain -> connection.close().
   describe('arnavmq.js close() orchestration', () => {
     const sandbox = sinon.createSandbox();
     afterEach(() => sandbox.restore());
@@ -988,17 +1105,6 @@ describe('graceful shutdown', () => {
         ...overrides,
       });
       return new ArnavMQ(conn);
-    }
-
-    /** Polls `predicate` every 20ms until truthy, or throws once `timeoutMs` elapses. */
-    async function waitFor(predicate, timeoutMs = 3000) {
-      const deadline = Date.now() + timeoutMs;
-      while (!predicate()) {
-        if (Date.now() >= deadline) {
-          throw new Error('waitFor() timed out');
-        }
-        await utils.timeoutPromise(20);
-      }
     }
 
     describe('the object returned by the top-level factory', () => {
@@ -1244,6 +1350,129 @@ describe('graceful shutdown', () => {
         elapsed < 5000,
         `expected close() to resolve quickly rather than waiting out rpcTimeout, took ${elapsed}ms`,
       );
+    });
+
+    // The reason producer.stop() runs first. A handler parked on an RPC response is in-flight, so
+    // drain() waits on it - and the only thing that can release it is producer.stop(). Draining
+    // first makes those two wait on each other: shutdown stalls for rpcTimeout per parked handler,
+    // and with rpcTimeout: 0 (newArnavmq()'s default here) no timer is ever armed, so close() never
+    // resolves at all and every later close() awaits that same memoized promise.
+    it('does not wait for a parked RPC response - close() resolves instead of deadlocking on the drain', async () => {
+      const arnavmq = newArnavmq();
+      const queue = 'shutdown:arnavmq-close:rpc-drain-deadlock';
+      // Deliberately unconsumed, so the request below cannot be answered while close() runs - the
+      // same position every peer in this process is in once close() has cancelled its consumers.
+      const peerQueue = 'shutdown:arnavmq-close:rpc-drain-deadlock:peer';
+
+      const handlerParked = pDefer();
+      const rpcOutcome = pDefer();
+
+      await arnavmq.subscribe(queue, async () => {
+        handlerParked.resolve();
+        try {
+          rpcOutcome.resolve({ answer: await arnavmq.publish(peerQueue, { ping: true }, { rpc: true }) });
+        } catch (error) {
+          rpcOutcome.resolve({ error });
+        }
+      });
+
+      await arnavmq.publish(queue, { n: 1 });
+      await handlerParked.promise;
+      await waitFor(() => !!arnavmq.producer.amqpRPCQueues[peerQueue]);
+      assert.strictEqual(arnavmq.consumer.inFlight(), 1, 'expected the parked handler to be in flight');
+
+      const start = Date.now();
+      await arnavmq.close();
+      const elapsed = Date.now() - start;
+
+      const outcome = await rpcOutcome.promise;
+      assert(
+        outcome.error instanceof ConnectionClosedError,
+        `expected the parked RPC to be rejected with ConnectionClosedError, got ${JSON.stringify(outcome)}`,
+      );
+      assert(elapsed < 3000, `expected close() not to wait on the parked RPC, took ${elapsed}ms`);
+      assert.strictEqual(arnavmq.connection.isClosed, true);
+    });
+
+    // The other half of the same ordering choice: stopping the producer must not stop a *draining*
+    // handler from finishing its work. Non-RPC publishes go out untouched (the connection is still
+    // open), and consumer.js's checkRpc() writes RPC replies straight to the channel rather than
+    // through the producer, so a handler that had already received an RPC request can still answer
+    // its caller. Only new outgoing RPC requests fail fast.
+    //
+    // The caller has to be a separate instance: producer.stop() rejects the *closing* instance's own
+    // pending waiters by design, so a same-instance caller would be rejected no matter what the
+    // reply path did, and would prove nothing about it.
+    it('a draining handler can still answer an RPC request it had already received', async () => {
+      const server = newArnavmq();
+      const caller = newArnavmq({ hostname: 'shutdown-arnavmq-close-test-caller', rpcTimeout: 15000 });
+      const queue = 'shutdown:arnavmq-close:reply-while-draining';
+
+      const proceedGate = pDefer();
+      await server.subscribe(queue, async () => {
+        await proceedGate.promise;
+        return { pong: true };
+      });
+
+      const callerPromise = caller.publish(queue, { ping: true }, { rpc: true });
+      await waitFor(() => server.consumer.inFlight() === 1);
+
+      const closePromise = server.close();
+      await utils.timeoutPromise(50); // cancelled, now draining; the handler is still gated
+      assert.strictEqual(server.connection.isClosed, false, 'connection must still be open mid-drain');
+
+      proceedGate.resolve(); // the handler returns, and checkRpc() writes the reply
+      assert.deepStrictEqual(await callerPromise, { pong: true });
+
+      await closePromise;
+      assert.strictEqual(server.connection.isClosed, true);
+      await caller.close();
+    });
+
+    // Same window, the outbound direction: once the producer is stopped a draining handler's plain
+    // publish() still has to go out (the connection is open until the last step), while a *new* RPC
+    // request must fail fast rather than register a waiter nothing is left to answer.
+    it('during the drain a handler can still publish, but a new RPC request fails fast', async () => {
+      const arnavmq = newArnavmq();
+      const queue = 'shutdown:arnavmq-close:publish-vs-rpc-while-draining';
+      const sideQueue = 'shutdown:arnavmq-close:publish-vs-rpc-while-draining:side';
+
+      const proceedGate = pDefer();
+      const outcomes = pDefer();
+      await arnavmq.subscribe(queue, async () => {
+        await proceedGate.promise;
+        const result = {};
+        try {
+          await arnavmq.publish(sideQueue, { plain: true });
+          result.plain = 'sent';
+        } catch (error) {
+          result.plain = error;
+        }
+        try {
+          await arnavmq.publish(sideQueue, { rpc: true }, { rpc: true });
+          result.rpc = 'answered';
+        } catch (error) {
+          result.rpc = error;
+        }
+        outcomes.resolve(result);
+      });
+
+      await arnavmq.publish(queue, { n: 1 });
+      await waitFor(() => arnavmq.consumer.inFlight() === 1);
+
+      const closePromise = arnavmq.close();
+      await utils.timeoutPromise(50);
+      proceedGate.resolve();
+
+      const result = await outcomes.promise;
+      assert.strictEqual(result.plain, 'sent', `expected a plain publish to still succeed, got ${result.plain}`);
+      assert(
+        result.rpc instanceof ConnectionClosedError,
+        `expected a new RPC request to fail fast with ConnectionClosedError, got ${result.rpc}`,
+      );
+
+      await closePromise;
+      assert.strictEqual(arnavmq.connection.isClosed, true);
     });
   });
 });

--- a/test/shutdown-spec.js
+++ b/test/shutdown-spec.js
@@ -855,79 +855,19 @@ describe('graceful shutdown', () => {
     });
   });
 
-  describe('producer.js reconnect-on-close guard', () => {
-    const sandbox = sinon.createSandbox();
-    afterEach(() => sandbox.restore());
-
-    /** A fake connection whose 'close' listeners are driven by a real EventEmitter, like the amqp one. */
-    function createFakeConnectionWithCloseEvent(channel) {
-      const emitter = new EventEmitter();
-      return {
-        config: { hostname: 'shutdown-producer-test', timeout: 10, rpcTimeout: 0 },
-        getDefaultChannel: sinon.stub().resolves(channel),
-        addListener(event, fn) {
-          emitter.on(event, fn);
-        },
-        emitClose() {
-          emitter.emit('close');
-        },
-      };
-    }
-
-    it('createRpcQueue() stops retrying (does not spin) once getDefaultChannel rejects with ConnectionClosedError', async () => {
-      const channel = createFakeChannelForRpc();
-      const connection = createFakeConnectionWithCloseEvent(channel);
-      connection.getDefaultChannel = sinon.stub().rejects(new ConnectionClosedError());
-      const producer = new Producer(connection);
-      const timeoutSpy = sandbox.spy(utils, 'timeoutPromise');
-
-      const result = await producer.createRpcQueue('shutdown:rpc:closed-from-start');
-
-      // one attempt, then the guard stops it: no internal retry-loop recursion, no delay-then-retry.
-      assert.strictEqual(result, undefined);
-      sinon.assert.notCalled(timeoutSpy);
-      sinon.assert.calledOnce(connection.getDefaultChannel);
-    });
-
-    it('the fire-and-forget reconnect-on-close listener stops spinning once the connection is permanently closed', async () => {
-      const channel = createFakeChannelForRpc();
-      const connection = createFakeConnectionWithCloseEvent(channel);
-      const producer = new Producer(connection);
-      const queue = 'shutdown:rpc:reconnect-then-closed';
-
-      // first init succeeds normally and registers the reconnect-on-close listener
-      await producer.createRpcQueue(queue);
-      sinon.assert.calledOnce(connection.getDefaultChannel);
-
-      // now simulate the connection being permanently closed
-      connection.getDefaultChannel = sinon.stub().rejects(new ConnectionClosedError());
-      const timeoutSpy = sandbox.spy(utils, 'timeoutPromise');
-
-      connection.emitClose(); // fires the registered listener, which fire-and-forgets createRpcQueue()
-
-      // give the fire-and-forget promise chain a tick to run to completion
-      await new Promise((resolve) => {
-        setTimeout(resolve, 20);
-      });
-
-      sinon.assert.calledOnce(connection.getDefaultChannel);
-      sinon.assert.notCalled(timeoutSpy);
-    });
-  });
-
-  // producer.js's stop() proactively rejects RPC promises pending in amqpRPCQueues (a separate code
-  // path from the reconnect-on-close guard above) so a caller awaiting an RPC response does not hang
-  // for the full rpcTimeout once the connection is gone.
-  describe('producer.js stop()', () => {
+  // Closing a channel is what makes every pending RPC request unanswerable, so producer.js hangs
+  // one listener on it and rejects its waiters from there. That covers a graceful close() and a
+  // socket that died on its own with the same code, and replaces the per-RPC-queue listener that
+  // used to fire-and-forget a queue rebuild.
+  describe('producer.js channel-close listener', () => {
     const sandbox = sinon.createSandbox();
     afterEach(() => sandbox.restore());
 
     function createFakeConnection(channel, overrides = {}) {
       return {
-        config: { hostname: 'shutdown-producer-stop-test', timeout: 10, rpcTimeout: 15000, ...overrides },
+        config: { hostname: 'shutdown-producer-test', timeout: 10, rpcTimeout: 15000, ...overrides },
         getDefaultChannel: sinon.stub().resolves(channel),
         getConnection: sinon.stub().resolves({}),
-        addListener: sinon.stub(),
       };
     }
 
@@ -938,95 +878,109 @@ describe('graceful shutdown', () => {
 
     it('rejects a pending RPC promise with ConnectionClosedError instead of waiting out rpcTimeout', async () => {
       const channel = createFakeChannelForRpc();
-      const connection = createFakeConnection(channel);
-      const producer = new Producer(connection);
-      const queue = 'shutdown:producer-stop:pending';
+      const producer = new Producer(createFakeConnection(channel));
+      const queue = 'shutdown:producer-close:pending';
 
       const rpcPromise = producer.checkRpc(queue, 'payload', { rpc: true });
-      // let createRpcQueue()/publishOrSendToQueue() settle so the waiter is actually registered
-      await utils.timeoutPromise(10);
-      assert(pendingCorrelationId(producer, queue), 'expected a pending RPC waiter to be registered');
+      await waitFor(() => !!pendingCorrelationId(producer, queue));
 
-      producer.stop();
+      channel.emit('close');
 
       await assert.rejects(() => rpcPromise, ConnectionClosedError);
     });
 
     it('clears the pending timeout so no lingering timer keeps the process alive', async () => {
       const channel = createFakeChannelForRpc();
-      const connection = createFakeConnection(channel, { rpcTimeout: 15000 });
-      const producer = new Producer(connection);
-      const queue = 'shutdown:producer-stop:clear-timeout';
+      const producer = new Producer(createFakeConnection(channel));
+      const queue = 'shutdown:producer-close:clear-timeout';
       const clearTimeoutSpy = sandbox.spy(global, 'clearTimeout');
 
       const rpcPromise = producer.checkRpc(queue, 'payload', { rpc: true });
-      await utils.timeoutPromise(10);
-
+      await waitFor(() => !!pendingCorrelationId(producer, queue));
       const corrId = pendingCorrelationId(producer, queue);
-      assert(corrId, 'expected a pending RPC waiter to be registered');
       const { timeoutId } = producer.amqpRPCQueues[queue][corrId];
       assert(timeoutId, 'expected a timer to have been scheduled for the pending RPC');
 
-      producer.stop();
+      channel.emit('close');
 
       sinon.assert.calledWith(clearTimeoutSpy, timeoutId);
-      assert.strictEqual(
-        pendingCorrelationId(producer, queue),
-        undefined,
-        'expected the waiter to be removed from the registry',
-      );
       await assert.rejects(() => rpcPromise, ConnectionClosedError);
     });
 
-    it('is idempotent - calling stop() twice does not throw or double-reject', async () => {
+    it('drops the dead reply-queue bookkeeping, so the next RPC publish rebuilds it', async () => {
       const channel = createFakeChannelForRpc();
-      const connection = createFakeConnection(channel);
-      const producer = new Producer(connection);
-      const queue = 'shutdown:producer-stop:idempotent';
+      const producer = new Producer(createFakeConnection(channel));
+      const queue = 'shutdown:producer-close:resqueue-rebuilt';
 
       const rpcPromise = producer.checkRpc(queue, 'payload', { rpc: true });
-      await utils.timeoutPromise(10);
+      await waitFor(() => !!pendingCorrelationId(producer, queue));
+      assert(producer.amqpRPCQueues[queue].resQueuePromise, 'expected a reply queue to have been set up');
 
-      producer.stop();
-      producer.stop();
-
+      channel.emit('close');
       await assert.rejects(() => rpcPromise, ConnectionClosedError);
-      assert.strictEqual(producer._shuttingDown, true);
+
+      // The reply queue was exclusive to the connection that just went away, so keeping its promise
+      // would hand every later RPC a replyTo naming a queue that no longer exists.
+      assert.strictEqual(producer.amqpRPCQueues[queue], undefined);
+      assert(await producer.createRpcQueue(queue), 'expected the next RPC publish to rebuild the reply queue');
     });
 
-    it('leaves resQueuePromise bookkeeping alone (only rejects correlationId waiters)', async () => {
+    it('is idempotent - a second close does not throw or double-reject', async () => {
       const channel = createFakeChannelForRpc();
-      const connection = createFakeConnection(channel);
-      const producer = new Producer(connection);
-      const queue = 'shutdown:producer-stop:resqueue-untouched';
+      const producer = new Producer(createFakeConnection(channel));
+      const queue = 'shutdown:producer-close:idempotent';
 
       const rpcPromise = producer.checkRpc(queue, 'payload', { rpc: true });
-      await utils.timeoutPromise(10);
+      await waitFor(() => !!pendingCorrelationId(producer, queue));
 
-      producer.stop();
+      channel.emit('close');
+      channel.emit('close');
+
       await assert.rejects(() => rpcPromise, ConnectionClosedError);
+    });
 
-      assert(
-        producer.amqpRPCQueues[queue].resQueuePromise,
-        'expected resQueuePromise to still be present after stop()',
-      );
+    // The listener has to be re-armed on each new channel (a reconnect gets a fresh one), which the
+    // remove-then-add in _initializeRpcQueue does - without piling up one listener per RPC queue on
+    // the channel every consumer and the reply path share.
+    it('stays at exactly one listener on the channel however many RPC queues are initialized', async () => {
+      const channel = createFakeChannelForRpc();
+      const producer = new Producer(createFakeConnection(channel));
+
+      await producer.createRpcQueue('shutdown:producer-close:listeners:a');
+      await producer.createRpcQueue('shutdown:producer-close:listeners:b');
+      await producer.createRpcQueue('shutdown:producer-close:listeners:c');
+
+      assert.strictEqual(channel.listenerCount('close'), 1);
+    });
+
+    it('createRpcQueue() stops retrying (does not spin) once getDefaultChannel rejects with ConnectionClosedError', async () => {
+      const channel = createFakeChannelForRpc();
+      const connection = createFakeConnection(channel);
+      connection.getDefaultChannel = sinon.stub().rejects(new ConnectionClosedError());
+      const producer = new Producer(connection);
+      const timeoutSpy = sandbox.spy(utils, 'timeoutPromise');
+
+      const result = await producer.createRpcQueue('shutdown:producer-close:closed-from-start');
+
+      // one attempt, then the guard stops it: no internal retry-loop recursion, no delay-then-retry.
+      assert.strictEqual(result, undefined);
+      sinon.assert.notCalled(timeoutSpy);
+      sinon.assert.calledOnce(connection.getDefaultChannel);
     });
 
     // checkRpc() registers the waiter *before* awaiting the publish and only attaches its own
-    // handler (`return await responsePromise.promise`) after it. A stop() landing in that window -
-    // which is exactly when close() now calls it - rejects a deferred nobody is listening to yet,
-    // and a rejection left unhandled for a full turn of the loop is fatal under Node's default
-    // `--unhandled-rejections=throw`: the process dies during the graceful shutdown that rejected
-    // it. Note the `settled` handler below is on checkRpc()'s own promise, which is a different
-    // promise than the deferred and does not mask this.
-    it('stop() landing while the RPC publish is still in flight does not leave the rejection unhandled', async () => {
+    // handler (`return await responsePromise.promise`) after it. A close landing in that window
+    // rejects a deferred nobody is listening to yet, and a rejection left unhandled for a full turn
+    // of the loop is fatal under Node's default `--unhandled-rejections=throw`. Note the `settled`
+    // handler below is on checkRpc()'s own promise, a different promise than the deferred, and does
+    // not mask this.
+    it('a close landing while the RPC publish is still in flight does not leave the rejection unhandled', async () => {
       const channel = createFakeChannelForRpc();
       const publishGate = pDefer();
       // A publish that is a real round-trip rather than a microtask, so the window is actually open.
       channel.sendToQueue = sinon.stub().callsFake(() => publishGate.promise);
-      const connection = createFakeConnection(channel);
-      const producer = new Producer(connection);
-      const queue = 'shutdown:producer-stop:publish-window';
+      const producer = new Producer(createFakeConnection(channel));
+      const queue = 'shutdown:producer-close:publish-window';
 
       let settled;
       const seen = await recordUnhandledRejections(async () => {
@@ -1036,12 +990,10 @@ describe('graceful shutdown', () => {
           (error) => error,
         );
 
-        // wait on the actual condition rather than a duration: the waiter is registered and the
-        // publish is in flight exactly once sendToQueue has been called.
         await waitFor(() => channel.sendToQueue.called);
         assert(pendingCorrelationId(producer, queue), 'expected the waiter to be registered');
 
-        producer.stop();
+        channel.emit('close');
         await nextTurn(); // the turn in which Node would report the rejection as unhandled
 
         publishGate.resolve(true); // now let the publish finish, so checkRpc() reaches its await
@@ -1050,41 +1002,62 @@ describe('graceful shutdown', () => {
       assert.deepStrictEqual(
         seen.map((error) => error && error.message),
         [],
-        'expected no unhandled rejection while stop() raced the in-flight publish',
+        'expected no unhandled rejection while the close raced the in-flight publish',
       );
       assert((await settled) instanceof ConnectionClosedError, 'expected the rejection to still reach the caller');
     });
 
-    it('deletes the waiter when the publish itself fails, so no orphan is left for a later stop()', async () => {
+    it('deletes the waiter when the publish itself fails, so nothing is left in the registry', async () => {
       const channel = createFakeChannelForRpc();
       channel.sendToQueue = sinon.stub().rejects(new Error('broker blip'));
-      const connection = createFakeConnection(channel);
-      const producer = new Producer(connection);
-      const queue = 'shutdown:producer-stop:publish-failed';
+      const producer = new Producer(createFakeConnection(channel));
+      const queue = 'shutdown:producer-close:publish-failed';
 
       await assert.rejects(() => producer.checkRpc(queue, 'payload', { rpc: true }), /broker blip/);
 
       // Left behind, the entry can never be settled - prepareTimeoutRpc() was never reached, so it
-      // has no timer - and a stop() minutes later would reject it with no handler attached at all.
+      // has no timer - and it would leak until the channel finally closed.
       assert.strictEqual(
         pendingCorrelationId(producer, queue),
         undefined,
         'expected no orphaned RPC waiter after a failed publish',
       );
+    });
 
-      const seen = await recordUnhandledRejections(async () => {
-        producer.stop();
+    // The win from putting this on the channel rather than in close(): the same code covers a
+    // connection that died on its own. amqplib routes every teardown through
+    // Connection.toClosed() -> _closeChannels() -> Channel.toClosed(), which emits 'close' on every
+    // channel - so a broker that goes away no longer leaves RPC callers hanging out rpcTimeout, or
+    // forever with rpcTimeout: 0.
+    it('rejects pending RPC waiters when the socket dies on its own, not just on close()', async () => {
+      const connection = new Connection({
+        host: 'amqp://localhost',
+        hostname: 'shutdown-producer-socket-death',
+        prefetch: 5,
+        timeout: 10,
+        rpcTimeout: 0, // no timer is armed at all, so only the listener can settle this
       });
-      assert.deepStrictEqual(
-        seen.map((error) => error && error.message),
-        [],
-        'expected no orphan to reject',
-      );
+      const mq = new ArnavMQ(connection);
+      const queue = 'shutdown:producer-close:socket-death';
+      // deliberately unconsumed - only the channel-close listener can ever settle this
+
+      const rpcPromise = mq.publish(queue, { ping: true }, { rpc: true });
+      await waitFor(() => !!pendingCorrelationId(mq.producer, queue));
+
+      // destroy(err) so the socket emits 'error', which is what amqplib wires its teardown to
+      // (along with 'end'). A bare destroy() emits only 'close', which amqplib does not listen for.
+      const amqpConnection = await connection.getConnection();
+      (amqpConnection.stream || amqpConnection.connection.stream).destroy(new Error('ECONNRESET (simulated)'));
+
+      await assert.rejects(() => rpcPromise, ConnectionClosedError);
+      assert.strictEqual(connection.isClosed, false, 'this was a drop, not a close() - isClosed stays false');
+      await connection.close();
     });
   });
 
-  // src/modules/arnavmq.js's top-level close() orchestrates, in order: producer.stop() -> cancel ->
-  // drain -> connection.close().
+  // src/modules/arnavmq.js's top-level close() orchestrates, in order: cancel -> drain ->
+  // connection.close(). Nothing else - failing pending RPC waiters falls out of closing the
+  // connection, via producer.js's channel-close listener.
   describe('arnavmq.js close() orchestration', () => {
     const sandbox = sinon.createSandbox();
     afterEach(() => sandbox.restore());
@@ -1336,12 +1309,11 @@ describe('graceful shutdown', () => {
       const rpcPromise = arnavmq.publish(queue, { ping: true }, { rpc: true });
       await utils.timeoutPromise(100); // let checkRpc()/createRpcQueue() register the pending waiter
 
-      // Attach the rejection expectation *before/alongside* close(), not after awaiting it: close()
-      // rejects rpcPromise synchronously from inside producer.stop(), several steps before close()
-      // itself resolves (it still has to await connection.close()). Awaiting close() to completion
-      // first and only then attaching a handler to rpcPromise leaves it unhandled across a real
-      // async gap, which trips Node's unhandledRejection detection - a test-harness ordering issue,
-      // not a bug in close() itself.
+      // Attach the rejection expectation *before/alongside* close(), not after awaiting it: the
+      // waiter is rejected from the channel-close listener partway through connection.close(),
+      // before close() itself resolves. Awaiting close() to completion first and only then
+      // attaching a handler to rpcPromise leaves it unhandled across a real async gap, which trips
+      // Node's unhandledRejection detection - a test-harness ordering issue, not a bug in close().
       const start = Date.now();
       await Promise.all([arnavmq.close(), assert.rejects(() => rpcPromise, ConnectionClosedError)]);
       const elapsed = Date.now() - start;
@@ -1352,57 +1324,12 @@ describe('graceful shutdown', () => {
       );
     });
 
-    // The reason producer.stop() runs first. A handler parked on an RPC response is in-flight, so
-    // drain() waits on it - and the only thing that can release it is producer.stop(). Draining
-    // first makes those two wait on each other: shutdown stalls for rpcTimeout per parked handler,
-    // and with rpcTimeout: 0 (newArnavmq()'s default here) no timer is ever armed, so close() never
-    // resolves at all and every later close() awaits that same memoized promise.
-    it('does not wait for a parked RPC response - close() resolves instead of deadlocking on the drain', async () => {
-      const arnavmq = newArnavmq();
-      const queue = 'shutdown:arnavmq-close:rpc-drain-deadlock';
-      // Deliberately unconsumed, so the request below cannot be answered while close() runs - the
-      // same position every peer in this process is in once close() has cancelled its consumers.
-      const peerQueue = 'shutdown:arnavmq-close:rpc-drain-deadlock:peer';
-
-      const handlerParked = pDefer();
-      const rpcOutcome = pDefer();
-
-      await arnavmq.subscribe(queue, async () => {
-        handlerParked.resolve();
-        try {
-          rpcOutcome.resolve({ answer: await arnavmq.publish(peerQueue, { ping: true }, { rpc: true }) });
-        } catch (error) {
-          rpcOutcome.resolve({ error });
-        }
-      });
-
-      await arnavmq.publish(queue, { n: 1 });
-      await handlerParked.promise;
-      await waitFor(() => !!arnavmq.producer.amqpRPCQueues[peerQueue]);
-      assert.strictEqual(arnavmq.consumer.inFlight(), 1, 'expected the parked handler to be in flight');
-
-      const start = Date.now();
-      await arnavmq.close();
-      const elapsed = Date.now() - start;
-
-      const outcome = await rpcOutcome.promise;
-      assert(
-        outcome.error instanceof ConnectionClosedError,
-        `expected the parked RPC to be rejected with ConnectionClosedError, got ${JSON.stringify(outcome)}`,
-      );
-      assert(elapsed < 3000, `expected close() not to wait on the parked RPC, took ${elapsed}ms`);
-      assert.strictEqual(arnavmq.connection.isClosed, true);
-    });
-
-    // The other half of the same ordering choice: stopping the producer must not stop a *draining*
-    // handler from finishing its work. Non-RPC publishes go out untouched (the connection is still
-    // open), and consumer.js's checkRpc() writes RPC replies straight to the channel rather than
-    // through the producer, so a handler that had already received an RPC request can still answer
-    // its caller. Only new outgoing RPC requests fail fast.
+    // A draining handler has to be able to finish its work, which includes answering an RPC request
+    // it had already received. consumer.js's checkRpc() writes the reply straight to the channel,
+    // and the connection stays open for the whole drain, so this keeps working.
     //
-    // The caller has to be a separate instance: producer.stop() rejects the *closing* instance's own
-    // pending waiters by design, so a same-instance caller would be rejected no matter what the
-    // reply path did, and would prove nothing about it.
+    // The caller is a separate instance so that closing the server cannot settle the caller's own
+    // waiter as a side effect - that would prove nothing about the reply actually arriving.
     it('a draining handler can still answer an RPC request it had already received', async () => {
       const server = newArnavmq();
       const caller = newArnavmq({ hostname: 'shutdown-arnavmq-close-test-caller', rpcTimeout: 15000 });
@@ -1429,50 +1356,51 @@ describe('graceful shutdown', () => {
       await caller.close();
     });
 
-    // Same window, the outbound direction: once the producer is stopped a draining handler's plain
-    // publish() still has to go out (the connection is open until the last step), while a *new* RPC
-    // request must fail fast rather than register a waiter nothing is left to answer.
-    it('during the drain a handler can still publish, but a new RPC request fails fast', async () => {
-      const arnavmq = newArnavmq();
-      const queue = 'shutdown:arnavmq-close:publish-vs-rpc-while-draining';
-      const sideQueue = 'shutdown:arnavmq-close:publish-vs-rpc-while-draining:side';
+    // The connection stays open for the whole drain, so everything a handler starts still works:
+    // a plain publish, and a brand new RPC request that gets a real answer. There is no producer
+    // shutdown flag turning these away any more.
+    it('during the drain a handler can still publish and still complete a new RPC round-trip', async () => {
+      const app = newArnavmq();
+      const peer = newArnavmq({ hostname: 'shutdown-arnavmq-close-test-peer' });
+      const queue = 'shutdown:arnavmq-close:work-while-draining';
+      const sideQueue = 'shutdown:arnavmq-close:work-while-draining:side';
+      const rpcQueue = 'shutdown:arnavmq-close:work-while-draining:rpc';
+
+      await peer.subscribe(rpcQueue, () => ({ pong: true }));
 
       const proceedGate = pDefer();
       const outcomes = pDefer();
-      await arnavmq.subscribe(queue, async () => {
+      await app.subscribe(queue, async () => {
         await proceedGate.promise;
         const result = {};
         try {
-          await arnavmq.publish(sideQueue, { plain: true });
+          await app.publish(sideQueue, { plain: true });
           result.plain = 'sent';
         } catch (error) {
           result.plain = error;
         }
         try {
-          await arnavmq.publish(sideQueue, { rpc: true }, { rpc: true });
-          result.rpc = 'answered';
+          result.rpc = await app.publish(rpcQueue, { ping: true }, { rpc: true });
         } catch (error) {
           result.rpc = error;
         }
         outcomes.resolve(result);
       });
 
-      await arnavmq.publish(queue, { n: 1 });
-      await waitFor(() => arnavmq.consumer.inFlight() === 1);
+      await app.publish(queue, { n: 1 });
+      await waitFor(() => app.consumer.inFlight() === 1);
 
-      const closePromise = arnavmq.close();
-      await utils.timeoutPromise(50);
+      const closePromise = app.close();
+      await utils.timeoutPromise(50); // cancelled, now draining; the handler is still gated
       proceedGate.resolve();
 
       const result = await outcomes.promise;
       assert.strictEqual(result.plain, 'sent', `expected a plain publish to still succeed, got ${result.plain}`);
-      assert(
-        result.rpc instanceof ConnectionClosedError,
-        `expected a new RPC request to fail fast with ConnectionClosedError, got ${result.rpc}`,
-      );
+      assert.deepStrictEqual(result.rpc, { pong: true }, `expected the RPC to be answered, got ${result.rpc}`);
 
       await closePromise;
-      assert.strictEqual(arnavmq.connection.isClosed, true);
+      assert.strictEqual(app.connection.isClosed, true);
+      await peer.close();
     });
   });
 });

--- a/test/shutdown-spec.js
+++ b/test/shutdown-spec.js
@@ -254,8 +254,14 @@ describe('graceful shutdown', () => {
           0,
           'cancelled subscriptions must not leave their resubscribe listener on the shared channel',
         );
-        // ...but the records themselves stay: inFlight() still reads them.
-        assert.strictEqual(consumer._subscriptions.length, 5, 'cancelled records must remain in the registry');
+        // ...and once cancelled+drained, the records themselves are dropped - otherwise repeated
+        // subscribe->cancel cycles would grow the registry (and its retained callbacks/options)
+        // without bound in a long-lived process.
+        assert.strictEqual(
+          consumer._subscriptions.length,
+          0,
+          'cancelled and drained records must not remain in the registry',
+        );
       });
     });
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,7 +7,7 @@
  * Any jsdoc comments with parameter descriptions were updated accordingly.
  */
 
-import { ConnectionConfig, Connection } from './modules/connection';
+import { ConnectionConfig, Connection, ConnectionClosedError } from './modules/connection';
 import Consumer = require('./modules/consumer');
 import Producer = require('./modules/producer');
 import { ConnectionHooks, ConsumerHooks, ProducerHooks } from './modules/hooks';
@@ -19,7 +19,16 @@ declare namespace arnavmqFactory {
   export type Arnavmq = arnavmq.Arnavmq;
   export type ArnavmqFactory = (config: ConnectionConfig) => Arnavmq;
 
-  export { ConnectionConfig, Connection, Consumer, Producer, ConnectionHooks, ConsumerHooks, ProducerHooks };
+  export {
+    ConnectionConfig,
+    Connection,
+    ConnectionClosedError,
+    Consumer,
+    Producer,
+    ConnectionHooks,
+    ConsumerHooks,
+    ProducerHooks,
+  };
 }
 
 export = arnavmqFactory;

--- a/types/modules/arnavmq.d.ts
+++ b/types/modules/arnavmq.d.ts
@@ -22,9 +22,6 @@ declare namespace arnavmq {
     consumer: {
       consume: typeof Consumer.prototype.consume;
       subscribe: typeof Consumer.prototype.consume;
-      cancel: typeof Consumer.prototype.cancel;
-      stop: typeof Consumer.prototype.stop;
-      drain: typeof Consumer.prototype.drain;
       inFlight: typeof Consumer.prototype.inFlight;
     };
     producer: {

--- a/types/modules/arnavmq.d.ts
+++ b/types/modules/arnavmq.d.ts
@@ -13,16 +13,12 @@ declare namespace arnavmq {
     produce: typeof Producer.prototype.produce;
     publish: typeof Producer.prototype.produce;
     /**
-     * Graceful shutdown: cancel consumers -> drain in-flight handlers (rejecting+requeueing any
-     * still running past the timeout) -> reject pending RPC waiters -> close the connection.
-     * Idempotent - repeated calls are cheap no-ops rather than re-running the sequence.
-     * @param options
-     * @param options.timeout Drain budget in ms, passed through to consumer.stop(). Defaults to
-     *   the `shutdownTimeout` config value (30000ms).
-     * @return Resolves once shutdown has completed (never rejects) with the drain outcome: whether
-     *   everything drained cleanly, and how many in-flight messages were abandoned per queue.
+     * Graceful shutdown: cancel consumers -> drain in-flight handlers (no timeout) -> reject
+     * pending RPC waiters -> close the connection. Idempotent - repeated calls are cheap no-ops
+     * rather than re-running the sequence.
+     * @return Resolves once shutdown has completed (never rejects).
      */
-    close: (options?: { timeout?: number }) => Promise<Consumer.StopResult>;
+    close: () => Promise<void>;
     consumer: {
       consume: typeof Consumer.prototype.consume;
       subscribe: typeof Consumer.prototype.consume;

--- a/types/modules/arnavmq.d.ts
+++ b/types/modules/arnavmq.d.ts
@@ -12,9 +12,24 @@ declare namespace arnavmq {
     subscribe: typeof Consumer.prototype.consume;
     produce: typeof Producer.prototype.produce;
     publish: typeof Producer.prototype.produce;
+    /**
+     * Graceful shutdown: cancel consumers -> drain in-flight handlers (rejecting+requeueing any
+     * still running past the timeout) -> reject pending RPC waiters -> close the connection.
+     * Idempotent - repeated calls are cheap no-ops rather than re-running the sequence.
+     * @param options
+     * @param options.timeout Drain budget in ms, passed through to consumer.stop(). Defaults to
+     *   the `shutdownTimeout` config value (30000ms).
+     * @return Resolves once shutdown has completed (never rejects) with the drain outcome: whether
+     *   everything drained cleanly, and how many in-flight messages were abandoned per queue.
+     */
+    close: (options?: { timeout?: number }) => Promise<Consumer.StopResult>;
     consumer: {
       consume: typeof Consumer.prototype.consume;
       subscribe: typeof Consumer.prototype.consume;
+      cancel: typeof Consumer.prototype.cancel;
+      stop: typeof Consumer.prototype.stop;
+      drain: typeof Consumer.prototype.drain;
+      inFlight: typeof Consumer.prototype.inFlight;
     };
     producer: {
       produce: typeof Producer.prototype.produce;

--- a/types/modules/arnavmq.d.ts
+++ b/types/modules/arnavmq.d.ts
@@ -13,14 +13,18 @@ declare namespace arnavmq {
     produce: typeof Producer.prototype.produce;
     publish: typeof Producer.prototype.produce;
     /**
-     * Graceful shutdown: reject pending RPC waiters -> cancel consumers -> drain in-flight
-     * handlers (no timeout) -> close the connection. Idempotent - repeated calls are cheap no-ops
-     * rather than re-running the sequence.
+     * Graceful shutdown: stop consuming -> let every in-flight handler finish (no timeout) ->
+     * close the connection. Idempotent - repeated calls are cheap no-ops rather than re-running
+     * the sequence.
      *
-     * Pending RPC waiters are rejected up front, so a handler awaiting a response never holds the
-     * drain open. From that point on a new outgoing RPC request fails with `ConnectionClosedError`;
-     * non-RPC publishes, and RPC replies from handlers still draining, keep working until the
-     * connection itself closes.
+     * The connection stays open for the whole drain, so a handler can finish its work: publish
+     * downstream, answer an RPC request it had already received, or complete a new RPC round-trip
+     * of its own. Anything a handler starts is waited on too.
+     *
+     * No drain timeout: a handler that never finishes means close() never resolves, which is left
+     * to the process orchestrator's kill grace period. Closing the connection is what fails any
+     * still-pending RPC waiter, with `ConnectionClosedError`, rather than letting it hang out
+     * `rpcTimeout`.
      * @return Resolves once shutdown has completed (never rejects).
      */
     close: () => Promise<void>;

--- a/types/modules/arnavmq.d.ts
+++ b/types/modules/arnavmq.d.ts
@@ -13,9 +13,14 @@ declare namespace arnavmq {
     produce: typeof Producer.prototype.produce;
     publish: typeof Producer.prototype.produce;
     /**
-     * Graceful shutdown: cancel consumers -> drain in-flight handlers (no timeout) -> reject
-     * pending RPC waiters -> close the connection. Idempotent - repeated calls are cheap no-ops
+     * Graceful shutdown: reject pending RPC waiters -> cancel consumers -> drain in-flight
+     * handlers (no timeout) -> close the connection. Idempotent - repeated calls are cheap no-ops
      * rather than re-running the sequence.
+     *
+     * Pending RPC waiters are rejected up front, so a handler awaiting a response never holds the
+     * drain open. From that point on a new outgoing RPC request fails with `ConnectionClosedError`;
+     * non-RPC publishes, and RPC replies from handlers still draining, keep working until the
+     * connection itself closes.
      * @return Resolves once shutdown has completed (never rejects).
      */
     close: () => Promise<void>;

--- a/types/modules/connection.d.ts
+++ b/types/modules/connection.d.ts
@@ -54,6 +54,14 @@ interface ConnectionConfig {
   logger?: Logger;
 }
 
+/**
+ * Thrown by `getConnection()` once `close()` has been called - the connection is terminally shut
+ * down for the process and will never reconnect.
+ */
+declare class ConnectionClosedError extends Error {
+  constructor(message?: string);
+}
+
 declare class Connection {
   constructor(config: ConnectionConfig);
 
@@ -64,6 +72,12 @@ declare class Connection {
   get config(): ConnectionConfig;
   set config(value: ConnectionConfig);
 
+  /**
+   * Whether `close()` has been called on this connection. Once true, it never goes back to false -
+   * the connection is terminally shut down for the process.
+   */
+  get isClosed(): boolean;
+
   getConnection(): Promise<amqp.ChannelModel>;
   getChannel(queue: string, config: channels.ChannelConfig): Promise<amqp.Channel>;
   getDefaultChannel(): Promise<amqp.Channel>;
@@ -73,6 +87,13 @@ declare class Connection {
    * @param func the callback function to execute when the event is called
    */
   addListener(on: string, func: Function): Promise<void>;
+  /**
+   * Terminally close this connection for the process. Idempotent - safe to call more than once,
+   * sequentially or concurrently; every caller shares the same underlying close. After this
+   * resolves, `getConnection()` (and anything built on it) rejects with `ConnectionClosedError`.
+   * @return Resolves once closed; never rejects.
+   */
+  close(): Promise<void>;
 
   private _connect(): Promise<amqp.ChannelModel>;
 }
@@ -90,12 +111,24 @@ declare namespace connection {
      * @param func the callback function to execute when the event is called
      */
     addListener(on: string, func: Function): Promise<void>;
+    /**
+     * Terminally close this connection for the process. Idempotent - safe to call more than once,
+     * sequentially or concurrently; every caller shares the same underlying close. After this
+     * resolves, `getConnection()` (and anything built on it) rejects with `ConnectionClosedError`.
+     * @return Resolves once closed; never rejects.
+     */
+    close(): Promise<void>;
+    /**
+     * Whether `close()` has been called on this connection. Once true, it never goes back to
+     * false - the connection is terminally shut down for the process.
+     */
+    get isClosed(): boolean;
 
     get config(): ConnectionConfig;
     set config(value: ConnectionConfig);
   }
 
-  export { ConnectionConfig };
+  export { ConnectionConfig, ConnectionClosedError };
 }
 
 export = connection;

--- a/types/modules/connection.d.ts
+++ b/types/modules/connection.d.ts
@@ -56,10 +56,14 @@ interface ConnectionConfig {
 
 /**
  * Thrown by `getConnection()` once `close()` has been called - the connection is terminally shut
- * down for the process and will never reconnect.
+ * down for the process and will never reconnect. Also used to fail pending work (e.g. RPC waiters)
+ * that a channel/connection close leaves unanswerable, whether that close was requested or not.
  */
 declare class ConnectionClosedError extends Error {
-  constructor(message?: string);
+  constructor(origin?: 'shutdown' | 'unexpected', message?: string);
+
+  /** Whether the connection went away because `close()` was called, or on its own. */
+  origin: 'shutdown' | 'unexpected';
 }
 
 declare class Connection {

--- a/types/modules/consumer.d.ts
+++ b/types/modules/consumer.d.ts
@@ -44,7 +44,12 @@ declare class Consumer {
    * @param queue    The RabbitMQ queue name
    * @param options  (Optional) Options for the queue (durable, persistent, etc.) and channel (with prefetch, `{ channel: { prefetch: 100 } }`)
    * @param callback Callback function executed when a message is received on the queue name, can return a promise
-   * @return A promise that resolves when connection is established and consumer is ready
+   * @return Resolves `true` once the broker has confirmed the consumer (basic.consume-ok), or
+   *   `false` if the subscription was cancelled before that. Failures that may still clear - the
+   *   channel cannot be opened, the queue cannot be declared as asked - are retried behind
+   *   `config.timeout` rather than resolved, so this stays pending while a queue is undeclarable
+   *   and never reports success for a subscription that is not consuming.
+   * @throws ConnectionClosedError if the connection has already been closed - shutdown is terminal.
    */
   consume(queue: string, options: ConsumeOptions, callback: ConsumeCallback): Promise<boolean>;
   /**
@@ -52,7 +57,8 @@ declare class Consumer {
    * Automatically answers with the callback response (can be a Promise)
    * @param queue    The RabbitMQ queue name
    * @param callback Callback function executed when a message is received on the queue name, can return a promise
-   * @return A promise that resolves when connection is established and consumer is ready
+   * @return See the three-argument overload.
+   * @throws ConnectionClosedError if the connection has already been closed - shutdown is terminal.
    */
   consume(queue: string, callback: ConsumeCallback): Promise<boolean>;
 
@@ -82,7 +88,7 @@ declare class Consumer {
   private stop(): Promise<void>;
   private _cancelAll(): Promise<void>;
   private _initializeChannel(subscription: Subscription): Promise<amqp.Channel>;
-  private _consumeQueue(channel: amqp.Channel, subscription: Subscription): Promise<void>;
+  private _consumeQueue(channel: amqp.Channel, subscription: Subscription): Promise<boolean>;
   private _rejectMessageAfterProcess(
     channel: amqp.Channel,
     subscription: Subscription,

--- a/types/modules/consumer.d.ts
+++ b/types/modules/consumer.d.ts
@@ -17,20 +17,8 @@ type Subscription = {
   onChannelClose: (() => void) | null;
   /** Set by `_cancelSubscription()`; once true this subscription never (re)subscribes again. */
   cancelled: boolean;
-  /** Messages whose handler is currently running. */
-  inFlightMessages: Set<amqp.Message>;
-  /** Messages requeued by `stop()`'s timeout path; a per-delivery guard against double ack/reject/RPC-reply. */
-  abandonedMessages: Set<amqp.Message>;
-};
-/** The outcome of a `stop()` (and, through it, of `arnavmq.close()`). */
-type StopResult = {
-  /** true if every in-flight handler finished inside the drain budget, false if messages were abandoned. */
-  drained: boolean;
-  /**
-   * Queue name -> how many in-flight messages were abandoned (rejected+requeued) on it. Empty on a
-   * clean drain. Intended for an abandoned-message shutdown metric.
-   */
-  abandoned: Record<string, number>;
+  /** Count of handlers currently running, not yet acked/rejected. */
+  inFlightCount: number;
 };
 
 declare class Consumer {
@@ -88,22 +76,17 @@ declare class Consumer {
    */
   cancelAll(): Promise<void>;
   /**
-   * Resolves true once every in-flight message handler has finished (inFlight() reaches 0), or
-   * false if `timeoutMs` elapses first. Cancels nothing - pair with `cancel()`/`cancelAll()`.
-   * @param timeoutMs How long to wait for in-flight handlers to finish. Defaults to 30s.
-   * @return true if drained before the timeout, false otherwise.
+   * Resolves once every in-flight message handler has finished (inFlight() reaches 0). Cancels
+   * nothing - pair with `cancel()`/`cancelAll()`. No timeout: a handler that never finishes means
+   * this never resolves.
    */
-  drain(timeoutMs?: number): Promise<boolean>;
+  drain(): Promise<void>;
   /**
-   * cancelAll(), then drain(options.timeout). Idempotent - repeated/concurrent calls share the one
-   * in-flight shutdown promise. If drain() times out, every message still in-flight is rejected
-   * with requeue=true and marked as abandoned, so the still-running handler's eventual
-   * ack/reject/RPC-reply for it becomes a no-op.
-   * @param options
-   * @param options.timeout Passed through to drain(). Defaults to 30s.
-   * @return The drain outcome: whether it drained cleanly, and how many messages were abandoned per queue.
+   * cancelAll(), then drain(). Idempotent - repeated/concurrent calls share the one in-flight
+   * shutdown promise.
+   * @return Resolves once every in-flight handler has finished.
    */
-  stop(options?: { timeout?: number }): Promise<StopResult>;
+  stop(): Promise<void>;
   /**
    * Count of currently in-flight messages (handler running, not yet acked/rejected).
    * @param queue When given, count only subscriptions on this queue; otherwise every subscription.
@@ -123,7 +106,7 @@ declare class Consumer {
 }
 
 declare namespace Consumer {
-  export { ConsumeOptions, ConsumeCallback, StopResult, Subscription };
+  export { ConsumeOptions, ConsumeCallback, Subscription };
 }
 
 export = Consumer;

--- a/types/modules/consumer.d.ts
+++ b/types/modules/consumer.d.ts
@@ -7,6 +7,31 @@ type ConsumeOptions = amqp.Options.AssertQueue & {
   channel: ChannelConfig;
 };
 type ConsumeCallback = (body: unknown, properties: amqp.MessageProperties) => Promise<unknown> | unknown;
+/** One consume()/subscribe() registration and its live state, tracked for resubscribe/shutdown. */
+type Subscription = {
+  queue: string;
+  options: ConsumeOptions;
+  callback: ConsumeCallback;
+  channel: amqp.Channel | null;
+  consumerTag: string | null;
+  onChannelClose: (() => void) | null;
+  /** Set by `_cancelSubscription()`; once true this subscription never (re)subscribes again. */
+  cancelled: boolean;
+  /** Messages whose handler is currently running. */
+  inFlightMessages: Set<amqp.Message>;
+  /** Messages requeued by `stop()`'s timeout path; a per-delivery guard against double ack/reject/RPC-reply. */
+  abandonedMessages: Set<amqp.Message>;
+};
+/** The outcome of a `stop()` (and, through it, of `arnavmq.close()`). */
+type StopResult = {
+  /** true if every in-flight handler finished inside the drain budget, false if messages were abandoned. */
+  drained: boolean;
+  /**
+   * Queue name -> how many in-flight messages were abandoned (rejected+requeued) on it. Empty on a
+   * clean drain. Intended for an abandoned-message shutdown metric.
+   */
+  abandoned: Record<string, number>;
+};
 
 declare class Consumer {
   constructor(connection: Connection);
@@ -33,7 +58,7 @@ declare class Consumer {
    * @param callback Callback function executed when a message is received on the queue name, can return a promise
    * @return A promise that resolves when connection is established and consumer is ready
    */
-  consume(queue: string, options: ConsumeOptions, callback: ConsumeCallback): Promise<true>;
+  consume(queue: string, options: ConsumeOptions, callback: ConsumeCallback): Promise<boolean>;
   /**
    * Create a durable queue on RabbitMQ and consumes messages from it - executing a callback function.
    * Automatically answers with the callback response (can be a Promise)
@@ -41,18 +66,55 @@ declare class Consumer {
    * @param callback Callback function executed when a message is received on the queue name, can return a promise
    * @return A promise that resolves when connection is established and consumer is ready
    */
-  consume(queue: string, callback: ConsumeCallback): Promise<true>;
+  consume(queue: string, callback: ConsumeCallback): Promise<boolean>;
 
   /** @see Consumer.consume */
-  subscribe(queue: string, options: ConsumeOptions, callback: ConsumeCallback): Promise<true>;
+  subscribe(queue: string, options: ConsumeOptions, callback: ConsumeCallback): Promise<boolean>;
   /** @see Consumer.consume */
-  subscribe(queue: string, callback: ConsumeCallback): Promise<true>;
+  subscribe(queue: string, callback: ConsumeCallback): Promise<boolean>;
 
-  private _initializeChannel(queue: string, options: ConsumeOptions, callback): Promise<amqp.Channel>;
-  private _consumeQueue(channel: amqp.Channel, queue: string, callback: ConsumeCallback): Promise<void>;
+  /**
+   * basic.cancel by consumerTag for every subscription on `queue`. Does NOT close the channel (it
+   * is shared with other consumers and with RPC replies) and does NOT wait for in-flight handlers
+   * - use `drain()`/`stop()` for that. Cancelled subscriptions are never resubscribed.
+   * @param queue The queue to stop consuming from.
+   * @return Resolves once every subscription on `queue` has been cancelled.
+   */
+  cancel(queue: string): Promise<void>;
+  /**
+   * cancel()s every subscription across every queue, and marks this consumer as shutting down so
+   * no subscription resubscribes/retries afterward.
+   * @return Resolves once every subscription has been cancelled.
+   */
+  cancelAll(): Promise<void>;
+  /**
+   * Resolves true once every in-flight message handler has finished (inFlight() reaches 0), or
+   * false if `timeoutMs` elapses first. Cancels nothing - pair with `cancel()`/`cancelAll()`.
+   * @param timeoutMs How long to wait for in-flight handlers to finish. Defaults to 30s.
+   * @return true if drained before the timeout, false otherwise.
+   */
+  drain(timeoutMs?: number): Promise<boolean>;
+  /**
+   * cancelAll(), then drain(options.timeout). Idempotent - repeated/concurrent calls share the one
+   * in-flight shutdown promise. If drain() times out, every message still in-flight is rejected
+   * with requeue=true and marked as abandoned, so the still-running handler's eventual
+   * ack/reject/RPC-reply for it becomes a no-op.
+   * @param options
+   * @param options.timeout Passed through to drain(). Defaults to 30s.
+   * @return The drain outcome: whether it drained cleanly, and how many messages were abandoned per queue.
+   */
+  stop(options?: { timeout?: number }): Promise<StopResult>;
+  /**
+   * Count of currently in-flight messages (handler running, not yet acked/rejected).
+   * @param queue When given, count only subscriptions on this queue; otherwise every subscription.
+   */
+  inFlight(queue?: string): number;
+
+  private _initializeChannel(subscription: Subscription): Promise<amqp.Channel>;
+  private _consumeQueue(channel: amqp.Channel, subscription: Subscription): Promise<void>;
   private _rejectMessageAfterProcess(
     channel: amqp.Channel,
-    queue: string,
+    subscription: Subscription,
     msg: amqp.Message,
     parsedBody: unknown,
     requeue: boolean,
@@ -61,7 +123,7 @@ declare class Consumer {
 }
 
 declare namespace Consumer {
-  export { ConsumeOptions, ConsumeCallback };
+  export { ConsumeOptions, ConsumeCallback, StopResult, Subscription };
 }
 
 export = Consumer;

--- a/types/modules/consumer.d.ts
+++ b/types/modules/consumer.d.ts
@@ -62,37 +62,25 @@ declare class Consumer {
   subscribe(queue: string, callback: ConsumeCallback): Promise<boolean>;
 
   /**
-   * basic.cancel by consumerTag for every subscription on `queue`. Does NOT close the channel (it
-   * is shared with other consumers and with RPC replies) and does NOT wait for in-flight handlers
-   * - use `drain()`/`stop()` for that. Cancelled subscriptions are never resubscribed.
-   * @param queue The queue to stop consuming from.
-   * @return Resolves once every subscription on `queue` has been cancelled.
+   * Count of currently in-flight messages across every subscription (handler running, not yet
+   * acked/rejected).
    */
-  cancel(queue: string): Promise<void>;
-  /**
-   * cancel()s every subscription across every queue, and marks this consumer as shutting down so
-   * no subscription resubscribes/retries afterward.
-   * @return Resolves once every subscription has been cancelled.
-   */
-  cancelAll(): Promise<void>;
+  inFlight(): number;
+
   /**
    * Resolves once every in-flight message handler has finished (inFlight() reaches 0). Cancels
-   * nothing - pair with `cancel()`/`cancelAll()`. No timeout: a handler that never finishes means
-   * this never resolves.
+   * nothing - pair with `stop()`. No timeout: a handler that never finishes means this never
+   * resolves.
    */
-  drain(): Promise<void>;
+  private _drain(): Promise<void>;
   /**
-   * cancelAll(), then drain(). Idempotent - repeated/concurrent calls share the one in-flight
-   * shutdown promise.
+   * Cancels every subscription across every queue, then _drain()s. Idempotent - repeated/concurrent
+   * calls share the one in-flight shutdown promise. Internal - not part of the object arnavmq.js's
+   * factory returns publicly; call `close()` on the top-level module instead.
    * @return Resolves once every in-flight handler has finished.
    */
-  stop(): Promise<void>;
-  /**
-   * Count of currently in-flight messages (handler running, not yet acked/rejected).
-   * @param queue When given, count only subscriptions on this queue; otherwise every subscription.
-   */
-  inFlight(queue?: string): number;
-
+  private stop(): Promise<void>;
+  private _cancelAll(): Promise<void>;
   private _initializeChannel(subscription: Subscription): Promise<amqp.Channel>;
   private _consumeQueue(channel: amqp.Channel, subscription: Subscription): Promise<void>;
   private _rejectMessageAfterProcess(

--- a/types/modules/hooks/consumer_hooks.d.ts
+++ b/types/modules/hooks/consumer_hooks.d.ts
@@ -16,9 +16,16 @@ interface ConsumeInfo {
   action: {
     /** The raw amqplib message */
     message: amqp.Message;
-    /** The deserialized message content */
+    /**
+     * The deserialized message content. Absent for a message being requeued during shutdown - see
+     * `requeued` on {@link AfterConsumeInfo} - since nothing is deserialized on that path.
+     */
     content: unknown;
-    /** The callback to be executed with the message */
+    /**
+     * The callback to be executed with the message. Not guaranteed to run: it is skipped when this
+     * hook returns `false`, and for a message requeued during shutdown. Close anything opened here
+     * from the "after process" event rather than from a wrapper around this callback.
+     */
     callback: Function;
   };
 }
@@ -61,6 +68,14 @@ type AfterConsumeInfo = {
   rejectError?: Error;
   /** An amqplib error in case of a failed message ack following a successful callback. */
   ackError?: Error;
+  /**
+   * True when the message was handed straight back to the broker without the consume callback
+   * running at all, because the subscription had already been cancelled - a delivery the broker had
+   * buffered before cancel-ok landed, which happens for up to `prefetch` messages per consumer on
+   * every shutdown. `content` is absent for these, and `error`/`ackError` are never set: nothing
+   * was processed and nothing was acked.
+   */
+  requeued?: boolean;
 };
 
 declare class ConsumerHooks extends BaseHooks {

--- a/types/modules/producer.d.ts
+++ b/types/modules/producer.d.ts
@@ -43,9 +43,10 @@ declare class Producer {
   /**
    * Create a RPC-ready queue
    * @param  queue the queue name in which we send a RPC request
-   * @return Resolves with the the response queue name when the answer response queue is ready to receive messages
+   * @return Resolves with the response queue name once it's ready to receive messages, or
+   *   undefined if the connection is closed.
    */
-  private createRpcQueue(queue: string): Promise<string>;
+  private createRpcQueue(queue: string): Promise<string | undefined>;
   /**
    * Produces a message to a queue through the default exchange, or publishes to the given exchange if the options have a `routingKey`, using it for the queue name.
    * @param queue The queue to send or exchange to publish to.
@@ -66,9 +67,10 @@ declare class Producer {
    * @param queue the queue to send `msg` on
    * @param msg string, object, number.. anything bufferable/serializable
    * @param options contain rpc property (if true, enable rpc for this message)
-   * @return Resolves when message is correctly sent, or when response is received when rpc is enabled
+   * @return When `options.rpc` is true, resolves with the parsed RPC response body once it
+   *   arrives; otherwise resolves with whether the message was sent.
    */
-  private checkRpc(queue: string, msg: Buffer, options: ProduceOptions): Promise<boolean>;
+  private checkRpc(queue: string, msg: Buffer, options: ProduceOptions): Promise<boolean | unknown>;
   /**
    * @deprecated Use publish instead
    * Ensure channel exists and send message using `checkRpc`
@@ -89,6 +91,12 @@ declare class Producer {
   ): Promise<unknown>;
 
   private _shouldRetry(error: Error | ProducerError, currentRetryNumber: number): boolean;
+  /**
+   * Rejects every RPC promise currently pending in `amqpRPCQueues` with `ConnectionClosedError`,
+   * and clears its timeout. Idempotent: a second call is a no-op. Internal - not part of the
+   * object producer.js's factory returns publicly.
+   */
+  private stop(): void;
 }
 
 declare namespace Producer {

--- a/types/modules/producer.d.ts
+++ b/types/modules/producer.d.ts
@@ -92,11 +92,12 @@ declare class Producer {
 
   private _shouldRetry(error: Error | ProducerError, currentRetryNumber: number): boolean;
   /**
-   * Rejects every RPC promise currently pending in `amqpRPCQueues` with `ConnectionClosedError`,
-   * and clears its timeout. Idempotent: a second call is a no-op. Internal - not part of the
-   * object producer.js's factory returns publicly.
+   * Channel 'close' listener. Rejects every RPC request still pending in `amqpRPCQueues` with
+   * `ConnectionClosedError` and clears its timeout, then drops the registry so the dead reply
+   * queue is rebuilt on the next RPC publish. Fires on a deliberate `close()` and on a connection
+   * lost unexpectedly alike. Internal.
    */
-  private stop(): void;
+  private _onChannelClose(): void;
 }
 
 declare namespace Producer {

--- a/types/modules/producer.d.ts
+++ b/types/modules/producer.d.ts
@@ -95,7 +95,8 @@ declare class Producer {
    * Channel 'close' listener. Rejects every RPC request still pending in `amqpRPCQueues` with
    * `ConnectionClosedError` and clears its timeout, then drops the registry so the dead reply
    * queue is rebuilt on the next RPC publish. Fires on a deliberate `close()` and on a connection
-   * lost unexpectedly alike. Internal.
+   * lost unexpectedly alike - the rejection's `origin` ('shutdown' vs 'unexpected') tells them
+   * apart. Internal.
    */
   private _onChannelClose(): void;
 }

--- a/types/modules/utils.d.ts
+++ b/types/modules/utils.d.ts
@@ -13,4 +13,9 @@ export namespace emptyLogger {
 export function getCorrelationId(options: { correlationId?: string }): string;
 declare function empty(): void;
 export declare function timeoutPromise(timer: number): Promise<void>;
+/**
+ * Resolves with `promise`, or rejects once `timeoutMs` elapses - whichever happens first.
+ * @param what Described in the timeout error message.
+ */
+export declare function withTimeout<T>(promise: Promise<T>, timeoutMs: number, what: string): Promise<T>;
 export {};


### PR DESCRIPTION
## Summary

Additive graceful-shutdown API, inert unless called. Public surface is four things: `arnavmq.close()`, `arnavmq.consumer.inFlight()`, `connection.isClosed`, and `ConnectionClosedError` (exported from the package entry point, so `instanceof` works at runtime). Version bump to 0.18.0 (minor, purely additive).

### Main focus: the consumer drains already in-flight messages before the connection closes

The point of this PR is that a message whose handler has already started running gets to finish and ack before we tear anything down, instead of being killed mid-flight and redelivered.

`arnavmq.close()` is two steps:

```js
async close() {
  await this.consumer.stop();   // cancel every subscription, then drain
  await this.connection.close(); // flush channels, then close the socket
}
```

1. **Cancel** every subscription by `consumerTag`, so the broker stops delivering new messages. Always by consumerTag, never by closing the shared channel — `DEFAULT_CHANNEL` is shared by every default-prefetch consumer on the connection, so closing it would take down unrelated consumers.
2. **Drain** — wait for every in-flight handler to run to completion and ack. A message the broker had already pushed into the client buffer before `cancel-ok` landed has not started its handler, so it is rejected/requeued immediately rather than being run; it goes back to the queue for another instance, and nothing is dropped.
3. **Close the connection** — round-trip `Channel.Close`/`Close-Ok` on every cached channel, then close the socket.

The connection stays open through cancel/drain on purpose: a draining handler may still `publish()` downstream, answer an RPC request it had already received, or complete a new RPC round-trip of its own. All of that keeps working, and anything a handler starts is waited on too. `connection.close()` is the first point at which publishing starts failing with `ConnectionClosedError`.

**There is no drain timeout.** A handler that never finishes means `close()` never resolves — deliberately left to the orchestrator's own kill grace period rather than this library abandoning in-flight work on a clock. That includes a handler awaiting an RPC response nobody is left to send (the peer is shutting down too, or is served by a consumer this process just cancelled): in that case the pod burns its grace period and gets SIGKILLed. That is an accepted, documented cost, chosen over a timeout that would abandon real work early — by the time the grace period runs out, the acks written by handlers that *did* finish were flushed to the broker long before, so nothing is at risk beyond a slow exit.

Also fixes a real, reproduced ~50% message-redelivery race on shutdown: `channel.ack()` is fire-and-forget in AMQP 0-9-1, so tearing down the raw connection right after a successful drain could lose the race against the broker's own disconnect-driven auto-requeue — a message that had been handled and acked would still be redelivered. Fixed by the `Channel.Close`/`Close-Ok` round-trip in step 3, which forces the broker to have processed the preceding acks. `Channel.Close` is bounded at 5s per channel so an unresponsive broker cannot hang shutdown at that step.

### Pending RPC requests fail fast, from a channel-close listener

An RPC request still waiting for its response when the channel goes away is rejected with `ConnectionClosedError`, from a single `'close'` listener the producer keeps on the channel.

This is not a shutdown step — earlier revisions of this PR had it as a `producer.stop()` call in `close()`, and that was wrong. The reply queue is exclusive to the connection, and every request already went out carrying that queue's name as its `replyTo`, so once the channel is gone no answer can arrive for those requests *ever* — not even after a reconnect. Making it reactive means the same code covers a deliberate `close()` and a connection dropped unexpectedly, with no shutdown-only flag and no hole.

Waiting for those responses instead was considered and rejected: by that point every locally-handled message has already finished, so the response resolves a promise inside a caller that is going away regardless — and with a long `rpcTimeout` (or `rpcTimeout: 0`, which arms no timer at all) waiting means blocking shutdown for that duration, or forever, on a peer that may never answer. Callers get a deterministic, catchable failure instead of a hang.

## Review instructions

**Read the final per-file diff, not the commit sequence.** The commits are historical: several later ones reverse decisions made in earlier ones (notably the `close()` step ordering, and `producer.stop()`, which was added and then removed entirely). Reviewing commit-by-commit means reviewing designs that are no longer in the branch.

Suggested file order:

1. [src/modules/consumer.js](src/modules/consumer.js) — the core of the PR. The subscription registry, `_onDelivery()`'s in-flight accounting, `_cancelSubscription()`, `_drain()`, `stop()`.
2. [src/modules/connection.js](src/modules/connection.js) + [src/modules/channels.js](src/modules/channels.js) — **the highest-risk part; please review closely.** `close()`/`isClosed` and the ack-flush-race fix in `Channels.closeAll()`.
3. [src/modules/producer.js](src/modules/producer.js) — the channel-close listener and the RPC waiter registry.
4. [src/modules/arnavmq.js](src/modules/arnavmq.js) — the two-step `close()`. Small, but the ordering rationale lives in its JSDoc.
5. [types/](types/), [test/shutdown-spec.js](test/shutdown-spec.js), [README.md](README.md) — declarations, ~1400 lines of new coverage, docs.

**What most needs a human eye:**

- **The absence of a drain timeout.** This is the one deliberate way `close()` can never resolve. The reasoning is above; disagreement with it is the most valuable review finding here.
- **In-flight accounting in `_onDelivery()`.** A message counted as in-flight but never decremented hangs `close()` forever, since there is no timeout. Every path out of the handler — success, throw, reject/requeue, parse failure — must decrement exactly once.
- **The buffered-message rejection path.** Confirm a message that arrived before `cancel-ok` really is requeued, not dropped or double-acked.
- **The channel flush in `connection.close()`.** Whether `Channel.Close`/`Close-Ok` per cached channel is genuinely sufficient to order the preceding acks ahead of the socket teardown, and whether a channel already closed by the broker is handled.
- **No-regression on the reconnect path.** `_isLive()` and the `isClosed` checks now gate resubscribe behavior. `test/disconnect-spec.js` is the gate and stays green, but the interaction between shutdown state and reconnect logic is worth a read.

**What you can safely skip:** the API is additive and inert unless `close()` is called, so existing-behavior regressions are concentrated in `consumer.js`'s consume path and the reconnect logic, not in the new methods themselves.

**Verifying locally:** `npm test` needs a real broker — `test/docker.js` brings one up. Individual specs: `npx mocha test/shutdown-spec.js --exit`.

## Also in this branch

- **`eslint:recommended` is now actually enabled.** The flat config passed `js.configs.recommended` to `FlatCompat`'s `recommendedConfig` option, which only tells the compat layer how to resolve `"eslint:recommended"` when some *other* config extends it — it never enables the rules. The config is now spread into the array directly. This is not cosmetic: it catches the `no-unsafe-finally` bug this branch shipped in `withTimeout` and fixed a few commits later (`return clearTimeout(timeoutId)` inside a `finally`, which swallowed the raced promise's result), which had been invisible to CI. Existing warnings were left as warnings so CI stays green.
- **Consumer cleanup.** `_consumeQueue()` was one 108-line method wrapped around a nested async closure; the delivery path is now four named methods. A redundant `_shuttingDown` flag was folded into the already-present `_stopPromise`, and a dead `try/catch` around `Channels.closeAll()` (which cannot reject) was removed from `Connection._close()`.

## Process note

Built by AI agents against a written design plan, every task run against a real dockerized RabbitMQ broker. History was reorganized into one commit per logical concern.

The follow-up commits came out of a point-by-point human-led audit of an AI-generated PR review, which flagged four real bugs (of which three sub-claims and two proposed fixes were wrong and rejected): a `close()` step ordering that could deadlock, an RPC waiter registered before its publish could fail, the eslint gap above, and the `producer.stop()` design that has now been removed. The current design — including "no drain timeout, let the orchestrator kill us" — is a deliberate human decision, taken over the AI reviewer's recommendation.

## Test plan

- [ ] `npm test` — 105 passing, 0 failing; `test/disconnect-spec.js` (the resubscribe/reconnect regression gate) green throughout
- [ ] `npm run lint` (eslint + prettier + tsc over `types/`) clean — exit 0
- [ ] Human review of the ack-flush-race fix and of the no-drain-timeout decision
